### PR TITLE
Parse comparisons and filter by certain criteria

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 config.toml
 juno_out.log
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,11 +1381,14 @@ dependencies = [
  "chrono",
  "clap",
  "command",
+ "csv",
  "env_logger",
  "futures",
+ "glob",
  "itertools 0.13.0",
  "log",
  "num-bigint",
+ "rctree",
  "regex",
  "serde",
  "serde_json",
@@ -1731,6 +1761,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rctree"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03e7866abec1101869ffa8e2c8355c4c2419d0214ece0cc3e428e5b94dea6e9"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 command = "0.0.0"
 env_logger = "0.11.3"
 log = "0.4.21"
-serde = { version = "1.0.199", features = ["derive"] }
+serde = {version = "1.0.199", features = ["derive"]}
 tokio = { version = "1.37.0", features = ["full"] }
-clap = { version = "4.5.4", features = ["cargo"] }
+clap = {version = "4.5.4", features = ["cargo"]}
 toml = "0.8.12"
 anyhow = "1.0.83"
 serde_json = "1.0.117"
@@ -23,3 +23,7 @@ async-std = "1.12.0"
 chrono = "0.4.38"
 num-bigint = "0.4.5"
 serde_with = "3.8.1"
+csv = "1.3.0"
+glob = "0.3.1"
+rctree = "0.6.0"
+

--- a/src/block_tracer.rs
+++ b/src/block_tracer.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::{info, debug};
 use starknet::{
     core::types::{BlockId, TransactionTraceWithHash},
     providers::{Provider, ProviderError},
@@ -52,8 +52,8 @@ pub async fn block_main() -> Result<(), ManagerError> {
     let mut juno_manager = JunoManager::new(JunoBranch::Native).await?;
     let trace_report = juno_manager.trace_block(block_number).await?;
 
-    println!("//Done {block_number}");
-    println!("{trace_report:?}");
+    info!("//Done {block_number}");
+    info!("{trace_report:?}");
 
     Ok(())
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use std::{fs::OpenOptions, path::Path};
 
 use anyhow::Context;
-use log::{debug, warn};
+use log::{debug, warn, info};
 use starknet::core::types::BlockId;
 
 use crate::juno_manager::{JunoBranch, JunoManager, ManagerError};
@@ -18,8 +18,8 @@ pub async fn get_sorted_blocks_with_tx_count(
     // First load the entire cache
     let cache_data = read_block_tx_counts_cache(cache_path);
     match &cache_data {
-        Ok(data) => println!("Got cache with {} elements", data.len()),
-        Err(err) => println!("Got err {err}"),
+        Ok(data) => info!("Got cache with {} elements", data.len()),
+        Err(err) => warn!("Got err {err}"),
     }
     // If no cache could be loaded, treat it as being empty
     let mut cache_data = cache_data.unwrap_or_default();

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,343 @@
+use crate::trace_comparison::{
+    BlockTraceComparison, BlockTraceResult, InnerCallComparison, InvokeComparison,
+};
+
+use glob::glob;
+use itertools::Itertools;
+use log::{info, warn};
+use num_bigint::BigUint;
+use rctree::{self, Node};
+use starknet::core::types::FieldElement;
+use std::{collections::HashMap, fs::OpenOptions, io::Write, path::Path};
+
+pub fn dump() {
+    let out_dir = Path::new("./out");
+
+    let mut top_level_calls: Vec<TransactionCall> = vec![];
+    for entry in glob("./results/trace-*").expect("failed to glob results") {
+        match entry {
+            Ok(path) => {
+                info!("reading {}", path.to_str().unwrap());
+                let new_calls = read_top_level_calls(path.as_path());
+                for call in new_calls.into_iter() {
+                    if !&call.inner_call.has_children() {
+                        top_level_calls.push(call)
+                    }
+                }
+            }
+            Err(err) => warn!("glob err: '{err:?}'"),
+        }
+    }
+
+    let mut log_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(out_dir.join("filtered.csv"))
+        .expect("Failed to open log file");
+
+    let out_table = top_level_calls
+        .iter()
+        .map(|call| call.to_vec())
+        .collect_vec();
+    let _ = writeln!(log_file, "{}", get_header_vec(out_table).join(", "));
+    for call in top_level_calls.iter() {
+        if let Err(write_err) = writeln!(log_file, "{}", call.to_vec().join(", ")) {
+            warn!("Failed to write err with error: '{write_err}'");
+        }
+    }
+
+    // Print calls by category.
+    let categorized = CategorizedCalls::from_calls(top_level_calls.iter());
+
+    let mut log_by_transactions = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(out_dir.join("filtered_by_transactions.log"))
+        .expect("Failed to open log file");
+    for (key, value) in categorized.by_transactions.iter() {
+        let _ = writeln!(log_by_transactions, "{}, {}", key, value.len());
+    }
+
+    let mut log_by_contract = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(out_dir.join("filtered_by_contract.log"))
+        .expect("Failed to open log file");
+    for (key, value) in categorized.by_contract.iter() {
+        let _ = writeln!(
+            log_by_contract,
+            "{}, {}",
+            felt_to_hex(key, true),
+            value.len()
+        );
+    }
+
+    let mut log_by_contract_selector = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(out_dir.join("filtered_by_contract_selector.log"))
+        .expect("Failed to open log file");
+    for (key, value) in categorized.by_contract_selector.iter() {
+        let _ = writeln!(
+            log_by_contract_selector,
+            "{}, {}, {}",
+            felt_to_hex(&key.0, true),
+            felt_to_hex(&key.1, true),
+            value.len()
+        );
+    }
+}
+
+#[derive(Clone)]
+pub struct TransactionCall {
+    transaction_hash: String,
+    inner_call: Node<InnerCall>,
+}
+
+fn get_header_vec(table: Vec<Vec<String>>) -> Vec<&'static str> {
+    match table.iter().max() {
+        Some(longest_column) => {
+            // First column headers.
+            vec!["transaction", "contract", "selector"]
+                .into_iter()
+                .chain(
+                    // The rest of the columns are: contract, selector
+                    (0..longest_column.len().saturating_sub(3)).map(|index| match index % 2 {
+                        0 => "contract",
+                        _ => "selector",
+                    }),
+                )
+                .take(longest_column.len())
+                .collect_vec()
+        }
+        None => vec![],
+    }
+}
+
+impl TransactionCall {
+    fn to_vec(&self) -> Vec<String> {
+        let mut fields = vec![
+            self.transaction_hash.clone(),
+            felt_to_hex(&self.inner_call.borrow().contract, true),
+            felt_to_hex(&self.inner_call.borrow().selector, true),
+        ];
+
+        let in_order_parents = self
+            .inner_call
+            .ancestors()
+            .skip(1)
+            .map(|node| node.borrow().to_tuple())
+            .collect_vec()
+            .into_iter()
+            .rev()
+            .collect_vec();
+
+        let in_order_children = self
+            .inner_call
+            .descendants()
+            .skip(1)
+            .map(|node| node.borrow().to_tuple())
+            .collect_vec();
+
+        for item in in_order_parents
+            .into_iter()
+            .chain(Some(self.inner_call.borrow().to_tuple()).into_iter())
+            .chain(in_order_children)
+        {
+            fields.push(item.0);
+            fields.push(item.1);
+        }
+        fields
+    }
+}
+
+#[derive(Clone)]
+pub struct InnerCall {
+    contract: FieldElement,
+    selector: FieldElement,
+}
+
+impl InnerCall {
+    fn to_tuple(&self) -> (String, String) {
+        (
+            felt_to_hex(&self.contract, true),
+            felt_to_hex(&self.selector, true),
+        )
+    }
+}
+
+fn push_or_add<K, T, S>(map: &mut HashMap<K, Vec<T>, S>, key: K, value: T)
+where
+    K: std::hash::Hash + Eq + PartialEq,
+    S: std::hash::BuildHasher,
+{
+    let option = map.get_mut(&key);
+    match option {
+        None => {
+            map.insert(key, vec![value]);
+        }
+        Some(elem) => {
+            elem.push(value);
+        }
+    }
+}
+
+struct CategorizedCalls {
+    by_transactions: HashMap<String, Vec<TransactionCall>>,
+    by_contract: HashMap<FieldElement, Vec<TransactionCall>>,
+    by_contract_selector: HashMap<(FieldElement, FieldElement), Vec<TransactionCall>>,
+}
+impl CategorizedCalls {
+    fn from_calls<'a, T>(calls: T) -> Self
+    where
+        T: Iterator<Item = &'a TransactionCall>,
+    {
+        let mut by_transactions = HashMap::<String, Vec<TransactionCall>>::new();
+        let mut by_contract = HashMap::<FieldElement, Vec<TransactionCall>>::new();
+        let mut by_contract_selector =
+            HashMap::<(FieldElement, FieldElement), Vec<TransactionCall>>::new();
+        for call in calls {
+            push_or_add(
+                &mut by_transactions,
+                call.transaction_hash.clone(),
+                call.clone(),
+            );
+            push_or_add(
+                &mut by_contract,
+                call.inner_call.borrow().contract,
+                call.clone(),
+            );
+            push_or_add(
+                &mut by_contract_selector,
+                (
+                    call.inner_call.borrow().contract,
+                    call.inner_call.borrow().selector,
+                ),
+                call.clone(),
+            );
+        }
+        Self {
+            by_transactions,
+            by_contract,
+            by_contract_selector,
+        }
+    }
+}
+
+fn read_top_level_calls(path: &Path) -> Vec<TransactionCall> {
+    let log_file = OpenOptions::new()
+        .read(true)
+        .write(false)
+        .open(path)
+        .expect("Failed to open log file");
+
+    //  BlockTraceComparison
+    let result: BlockTraceResult =
+        serde_json::from_reader(log_file).expect("failed to read comparison file");
+    info!("block: {}", result.block_number);
+    get_top_level_calls(result.comparison)
+}
+
+fn get_top_level_calls(block_trace_comparison: BlockTraceComparison) -> Vec<TransactionCall> {
+    match block_trace_comparison {
+        BlockTraceComparison::BothSucceeded {
+            transaction_traces: trace_comparisons,
+        } => {
+            trace_comparisons
+                .iter()
+                .filter_map(|comparison| {
+                    match comparison {
+                        crate::trace_comparison::TransactionTraceComparison::Both {
+                            transaction_hash,
+                            body:
+                                crate::trace_comparison::TransactionTraceComparisonBody::Invoke(
+                                    invocation_comparison,
+                                ),
+                        } => build_inner_calls(invocation_comparison).map(|calls| {
+                            calls
+                                .iter()
+                                .map(|inner_call| TransactionCall {
+                                    transaction_hash: transaction_hash.clone(),
+                                    inner_call: inner_call.clone(),
+                                })
+                                .collect_vec()
+                        }), // Comparison::Both
+                        _ => None,
+                    }
+                }) // filter map
+                .flatten()
+                .collect_vec()
+        }
+        BlockTraceComparison::BaseFailed(_) => vec![],
+        BlockTraceComparison::NativeFailed(_) => vec![],
+        BlockTraceComparison::BothFailed {
+            base_error: _,
+            native_error: _,
+        } => vec![],
+    }
+}
+
+fn build_inner_calls(comparison: &InvokeComparison) -> Option<Vec<Node<InnerCall>>> {
+    match comparison {
+        InvokeComparison::BothSucceeded {
+            results,
+            inner_calls,
+        } => match results {
+            crate::trace_comparison::CallResultComparison::Same => None, // TODO add back in to innerCall struct?
+            crate::trace_comparison::CallResultComparison::Different { base: _, native: _ } => {
+                Some(
+                    inner_calls
+                        .iter()
+                        .map(|inner_comparison| {
+                            let this_node = Node::new(InnerCall {
+                                contract: inner_comparison.contract,
+                                selector: inner_comparison.selector,
+                            });
+                            for node in _build_inner_calls(inner_comparison) {
+                                this_node.append(node)
+                            }
+                            this_node
+                        })
+                        // .flatten()
+                        .collect(),
+                )
+            }
+        },
+        _ => None,
+    }
+}
+
+fn _build_inner_calls(comparison: &InnerCallComparison) -> Vec<Node<InnerCall>> {
+    match &comparison.info {
+        crate::trace_comparison::InnerCallComparisonInfo::Different {
+            inner_calls,
+            base: _,
+            native: _,
+        } => inner_calls
+            .iter()
+            .map(|inner_call_comparison| {
+                let inner_call = Node::new(InnerCall {
+                    contract: inner_call_comparison.contract,
+                    selector: inner_call_comparison.selector,
+                });
+                for child in _build_inner_calls(inner_call_comparison) {
+                    inner_call.append(child);
+                }
+                inner_call
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+// TODO this is a duplicate method with trace_comparison.rs
+fn felt_to_hex(value: &FieldElement, with_prefix: bool) -> String {
+    match with_prefix {
+        true => format!("0x{}", felt_to_hex(value, false)),
+        false => BigUint::from_bytes_be(&value.to_bytes_be()).to_str_radix(16),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod juno_manager;
 mod trace_comparison;
 mod transaction_simulator;
 mod transaction_tracer;
+mod filters;
 
 use block_tracer::{BlockTracer, TraceBlockReport};
 use cache::get_sorted_blocks_with_tx_count;
@@ -143,6 +144,7 @@ async fn execute_traces(start_block: u64, end_block: u64) {
 #[tokio::main]
 async fn main() {
     setup_env_logger();
+    filters::dump();
 
     let cli = command!()
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,23 +116,23 @@ async fn execute_traces(start_block: u64, end_block: u64) {
                 .unwrap();
             // Note that this doesn't compare the reasons for failure or the result on a success
             let successes = result.iter().filter(|result| result.is_correct()).count();
-            println!(
+            info!(
                 "Completed block {block_number} with {successes}/{} successes",
                 result.len()
             );
             log_block_report(block_number, result);
         } else {
             let native_report = native_result.unwrap();
-            println!("{}", native_report.result);
+            info!("{}", native_report.result);
             info!("Tracing block {block_number} with Base. It has {tx_count} transactions");
             let base_result = try_base_block_trace(block_number).await;
             match base_result {
                 Ok(base_report) => {
-                    println!("{}", base_report.result);
+                    info!("{}", base_report.result);
                     log_trace_comparison(block_number, native_report, base_report);
                 }
                 Err(err) => {
-                    println!("{err:?}");
+                    warn!("{err:?}");
                     log_trace_crash(block_number, err);
                 }
             }

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -1,6 +1,6 @@
 use itertools::{EitherOrBoth, Itertools};
 use num_bigint::BigUint;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use starknet::core::types::{
     BlockId, ExecuteInvocation, FieldElement, FunctionInvocation, TransactionTrace,
     TransactionTraceWithHash,
@@ -11,14 +11,14 @@ use starknet::core::types::{
 use crate::block_tracer::TraceBlockReport;
 
 // TODO more distinct naming
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BlockTraceResult {
-    block_number: u64,
-    comparison: BlockTraceComparison,
+    pub block_number: u64,
+    pub comparison: BlockTraceComparison,
 }
 
-#[derive(Serialize)]
-enum BlockTraceComparison {
+#[derive(Serialize, Deserialize)]
+pub enum BlockTraceComparison {
     BothSucceeded {
         transaction_traces: Vec<TransactionTraceComparison>,
     },
@@ -30,8 +30,8 @@ enum BlockTraceComparison {
     },
 }
 
-#[derive(Serialize)]
-enum TransactionTraceComparison {
+#[derive(Serialize, Deserialize)]
+pub enum TransactionTraceComparison {
     BaseOnly {
         transaction_hash: String,
     },
@@ -45,8 +45,8 @@ enum TransactionTraceComparison {
     },
 }
 
-#[derive(Serialize)]
-enum TransactionTraceComparisonBody {
+#[derive(Serialize, Deserialize)]
+pub enum TransactionTraceComparisonBody {
     Mismatch { base: String, native: String },
     Invoke(InvokeComparison),
     DeployAccount,
@@ -54,8 +54,8 @@ enum TransactionTraceComparisonBody {
     Declare,
 }
 
-#[derive(Serialize)]
-enum InvokeComparison {
+#[derive(Serialize, Deserialize)]
+pub enum InvokeComparison {
     BaseFailed(String),
     BothFailed {
         base_reason: String,
@@ -68,14 +68,14 @@ enum InvokeComparison {
     NativeFailed(Vec<String>),
 }
 
-#[derive(Serialize)]
-enum CallResultComparison {
+#[derive(Serialize, Deserialize)]
+pub enum CallResultComparison {
     Same,
     Different { base: String, native: String },
 }
 
-#[derive(Serialize)]
-enum InnerCallComparisonInfo {
+#[derive(Serialize, Deserialize)]
+pub enum InnerCallComparisonInfo {
     Same,
     Different {
         inner_calls: Vec<InnerCallComparison>,
@@ -86,13 +86,13 @@ enum InnerCallComparisonInfo {
     NativeOnly,
 }
 
-#[derive(Serialize)]
-struct InnerCallComparison {
+#[derive(Serialize, Deserialize)]
+pub struct InnerCallComparison {
     #[serde(serialize_with = "hex_serialize")]
-    contract: FieldElement,
+    pub contract: FieldElement,
     #[serde(serialize_with = "hex_serialize")]
-    selector: FieldElement,
-    info: InnerCallComparisonInfo,
+    pub selector: FieldElement,
+    pub info: InnerCallComparisonInfo,
 }
 
 pub fn hex_serialize<S>(val: &FieldElement, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use log::{info, warn};
+
 use starknet::{
     core::types::{FieldElement, StarknetError},
     providers::{Provider, ProviderError},
@@ -71,7 +73,7 @@ impl TransactionTracer for JunoManager {
         &mut self,
         transaction_hash: &str,
     ) -> Result<TraceTransactionReport, ManagerError> {
-        println!("Tracing transaction {transaction_hash}");
+        info!("Tracing transaction {transaction_hash}");
         self.ensure_usable().await?;
         let transaction = FieldElement::from_hex_be(transaction_hash)
             .map_err(|e| ManagerError::InternalError(format!("{}", e)))?;
@@ -80,11 +82,11 @@ impl TransactionTracer for JunoManager {
         let result_type = match &trace_result {
             Ok(_) => TraceResult::Success,
             Err(err) => {
-                println!("err: '{:?}''", err);
+                warn!("err: '{:?}''", err);
                 TraceResult::from(err)
             }
         };
-        println!("{result_type}");
+        info!("{result_type}");
 
         self.ensure_dead().await?;
 
@@ -102,18 +104,18 @@ pub async fn transaction_hash_main() -> Result<(), ManagerError> {
     let hash = "0x07e3ace3b1c3f76b83b734b7a2ea990fb2823e931fb2ecef5d2677887aed9082"; // Crashes on native
     let mut juno_manager = JunoManager::new(JunoBranch::Native).await?;
     let trace_report = juno_manager.trace_transaction(hash).await?;
-    println!("transaction: {:?}", trace_report.transaction);
-    println!("result: {}", trace_report.result);
+    info!("transaction: {:?}", trace_report.transaction);
+    info!("result: {}", trace_report.result);
     match trace_report.post_response {
         Ok(item) => {
-            println!("item: {:?}", item);
+            info!("item: {:?}", item);
         }
         Err(err) => {
-            println!("error: {}", err);
+            warn!("error: {}", err);
         }
     };
 
-    println!("//Done {hash}");
+    info!("//Done {hash}");
 
     Ok(())
 }


### PR DESCRIPTION
Parses the trace-* files and dumps transaction_hash, contract, selector for different Invoke calls that have no children calls and no parent calls. Note that this does not mean they have no sibling calls.
