### PR TITLE
Added --run-known flag.

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -33,9 +33,11 @@ pub async fn get_sorted_blocks_with_tx_count(
 
     // For each block, use its cached result if present, and if not then ask juno and add it to the cache data
     for block_num in block_start..block_end {
+      debug!("Searching for {block_num} in cache");
         match cache_data.binary_search_by(|(x, _)| x.cmp(&block_num)) {
             Ok(idx) => result.push(cache_data[idx]),
             Err(idx) => {
+                debug!("{block_num} not found in cache. get_block_transaction_count");
                 let tx_count = juno_manager
                     .get_block_transaction_count(BlockId::Number(block_num))
                     .await?;


### PR DESCRIPTION
This helps avoid re-computing the same blocks without having to change ranges to navigate around the small blocks.

Commit message
```
When --skip-known is set, blocks that already have results will be skipped. Whether a block has results is determined by checking for the existence of either `results/block-<hash>.json` or `results/trace-<hash>.json`.
```