### PR TITLE
Refactor over IO and small changes to CLI and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ or
 target/cprof/juno_compare_traces range 610508 611000
 ```
 
-The tester once it runs a block, it won't re-running it again unless the `--run-known` flag is used.
-There are some extra options like this for each of these commands. Please be sure to execute `--help` to know about them:
+Once the tester has traced a block, it will store the output in `./results/<name>.json` and it won't re-do it again unless explicetly told with the `redo-comp` flag.
+The tool has many other options like this, please run the CLI with `--help` to get detailed information of all the commands and options.
 
 ```bash
 target/cprof/juno_compare_traces --help
@@ -104,7 +104,7 @@ target/cprof/juno_compare_traces --help
 
 ### Logging
 
-The tool will log it's execution. Currently it default to `debug`, but you can set any of the other logging profiles (i.e. `info`, `warn` and `error`) setting the `LOG_LEVEL` variable.
+The tool will log it's execution. Currently it defaults to `debug`, but you can set any of the other logging profiles (i.e. `info`, `warn` and `error`) setting the `LOG_LEVEL` variable.
 
 ```
 LOG_LEVEL=info juno_compare_traces range 610508 611000

--- a/src/block_tracer.rs
+++ b/src/block_tracer.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use starknet::{
     core::types::{BlockId, TransactionTraceWithHash},
     providers::Provider,
@@ -10,7 +10,7 @@ use crate::{
     transaction_tracer::TraceResult,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TraceBlockReport {
     pub block_num: u64,
     pub post_response: Option<Vec<TransactionTraceWithHash>>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,12 @@ pub struct Cli {
     /// Enables `SKIP_VALIDATE` mode for simulating transactions.
     #[clap(long)]
     pub skip_validate: bool,
-    /// Forces action even if an output file (block- or trace-) already exists for block
+    /// Forces the comparison between base and native if this already exists.
     #[clap(long)]
-    pub run_known: bool,
+    pub redo_comp: bool,
+    /// Forces the tracing of a block with base juno if this already exists.
+    #[clap(long)]
+    pub redo_base_trace: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,109 @@
+use serde_json::Value;
+use std::{fs::OpenOptions, path::PathBuf};
+use tokio::{
+    fs::OpenOptions as AsyncOpenOptions,
+    io::{AsyncWriteExt, BufWriter},
+};
+
+use log::{debug, info, warn};
+
+use crate::{
+    block_tracer::TraceBlockReport, juno_manager::ManagerError,
+    transaction_simulator::SimulationReport,
+};
+
+pub fn succesful_comparison_path(block_num: u64) -> PathBuf {
+    PathBuf::from(format!("results/comparison-{}.json", block_num))
+}
+
+pub fn crashed_comparison_path(block_num: u64) -> PathBuf {
+    PathBuf::from(format!("results/crash-{}.json", block_num))
+}
+
+pub fn unexpected_error_comparison_path(block_num: u64) -> PathBuf {
+    PathBuf::from(format!("results/unexpected-error-{}.json", block_num))
+}
+
+pub fn base_trace_path(block_num: u64) -> PathBuf {
+    PathBuf::from(format!("results/base/trace-{}.json", block_num))
+}
+
+// Creates a file in ./results/trace-{`block_number`}.json with the a full trace comparison between
+// base blockifier and native blockifier results
+pub async fn log_comparison_report(block_number: u64, comparison: Value) {
+    let mut buffer = Vec::new();
+    serde_json::to_writer_pretty(&mut buffer, &comparison).unwrap();
+
+    let log_file = AsyncOpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(succesful_comparison_path(block_number))
+        .await
+        .expect("Failed to open log file");
+
+    let mut writer = BufWriter::new(log_file);
+    writer.write_all(&buffer).await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+pub fn log_crash_report(block_number: u64, report: Vec<SimulationReport>) {
+    info!("Log report for block {block_number}");
+    let block_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(crashed_comparison_path(block_number))
+        .expect("Failed to open log file");
+
+    serde_json::to_writer_pretty(block_file, &report)
+        .unwrap_or_else(|_| panic!("failed to write block: {block_number}"));
+}
+
+// Creates a file in ./results/crash-{`block_number`}.json with the failure reason
+pub async fn log_unexpected_error_report(block_number: u64, err: ManagerError) {
+    let mut log_file = AsyncOpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(unexpected_error_comparison_path(block_number))
+        .await
+        .expect("Failed to open log file");
+    if let Err(write_err) = log_file.write_all(format!("{err:?}").as_bytes()).await {
+        warn!("Failed to write err with error: '{write_err}'");
+    }
+}
+
+// Creates a file in ./results/base/trace-{`block_number`}.json with the block trace by Base Juno
+pub async fn log_base_trace(block_number: u64, trace: &TraceBlockReport) {
+    info!("Log trace for block {block_number}");
+
+    let block_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(base_trace_path(block_number))
+        .expect("Failed to open log file");
+
+    serde_json::to_writer_pretty(block_file, &trace)
+        .unwrap_or_else(|_| panic!("failed to write block: {block_number}"));
+}
+
+pub async fn read_base_trace(block_number: u64) -> TraceBlockReport {
+    info!("Reading cached trace for block {block_number}");
+
+    let block_file = OpenOptions::new()
+        .read(true)
+        .open(base_trace_path(block_number))
+        .expect("Failed to read base trace");
+
+    serde_json::from_reader(block_file).expect("Couldn't parse JSON")
+}
+
+pub async fn prepare_directories() {
+    debug!("Preparing directories");
+    tokio::fs::create_dir_all("./results").await.unwrap();
+    tokio::fs::create_dir_all("./cache").await.unwrap();
+    tokio::fs::create_dir_all("./results/base").await.unwrap();
+    tokio::fs::create_dir_all("./results/native").await.unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod block_tracer;
 mod cache;
 mod cli;
 mod graph;
+mod io;
 mod juno_manager;
 mod trace_comparison;
 mod transaction_simulator;
@@ -9,62 +10,24 @@ mod transaction_tracer;
 
 use crate::cli::{Cli, Commands};
 use crate::graph::write_transactions_dependencies;
-use crate::transaction_simulator::log_base_trace;
-use block_tracer::{BlockTracer, TraceBlockReport};
+use crate::io::{
+    base_trace_path, crashed_comparison_path, log_base_trace, log_comparison_report,
+    log_crash_report, log_unexpected_error_report, read_base_trace, succesful_comparison_path,
+};
+use block_tracer::BlockTracer;
 use cache::get_sorted_blocks_with_tx_count;
 use chrono::Local;
 use clap::Parser;
 use core::panic;
 use env_logger::Env;
+use io::prepare_directories;
 use juno_manager::{JunoBranch, JunoManager, ManagerError};
 use log::{error, info, warn};
 use starknet::core::types::SimulationFlag;
 use std::io::Write;
-use std::path::Path;
-use tokio::fs::OpenOptions;
-use tokio::io::{AsyncWriteExt, BufWriter};
 use trace_comparison::generate_block_comparison;
-use transaction_simulator::{log_block_report, SimulationStrategy, TransactionSimulator};
+use transaction_simulator::{SimulationStrategy, TransactionSimulator};
 use transaction_tracer::TraceResult;
-
-// Creates a file in ./results/err-{`block_number`}.json with the failure reason
-async fn log_trace_crash(block_number: u64, err: ManagerError) {
-    let mut log_file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(format!("./results/err-{block_number}.json"))
-        .await
-        .expect("Failed to open log file");
-    if let Err(write_err) = log_file.write_all(format!("{err:?}").as_bytes()).await {
-        warn!("Failed to write err with error: '{write_err}'");
-    }
-}
-
-// Creates a file in ./results/trace-{`block_number`}.json with the a full trace comparison between
-// base blockifier and native blockifier results
-async fn log_trace_comparison(
-    block_number: u64,
-    native_report: TraceBlockReport,
-    base_report: TraceBlockReport,
-) {
-    let comparison = generate_block_comparison(base_report, native_report);
-
-    let mut buffer = Vec::new();
-    serde_json::to_writer_pretty(&mut buffer, &comparison).unwrap();
-
-    let log_file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(format!("./results/trace-{block_number}.json"))
-        .await
-        .expect("Failed to open log file");
-
-    let mut writer = BufWriter::new(log_file);
-    writer.write_all(&buffer).await.unwrap();
-    writer.flush().await.unwrap();
-}
 
 fn setup_env_logger() {
     env_logger::Builder::from_env(Env::default().filter_or("LOG_LEVEL", "debug"))
@@ -80,15 +43,11 @@ fn setup_env_logger() {
         .init();
 }
 
-fn results_exist_for_block(block: u64) -> bool {
-    Path::new(&format!("results/trace-{}.json", block)).exists()
-        || Path::new(&format!("results/block-{}.json", block)).exists()
-}
-
 async fn execute_traces(
     start_block: u64,
     end_block: u64,
-    should_run_known: bool,
+    redo_comparison: bool,
+    redo_traces: bool,
     simulation_flags: Vec<SimulationFlag>,
 ) -> Result<(), ManagerError> {
     let mut base_juno = JunoManager::new(JunoBranch::Base).await?;
@@ -98,15 +57,24 @@ async fn execute_traces(
             .unwrap();
 
     for (block_number, tx_count) in blocks_with_tx_count {
-        if !should_run_known && results_exist_for_block(block_number) {
-            info!("Skipping block {block_number} because results exist (use --run-known to run anyways)");
+        if !redo_comparison
+            && (succesful_comparison_path(block_number).exists()
+                || crashed_comparison_path(block_number).exists())
+        {
+            info!("Skipping comparison for block {block_number} because it's already logged (use --redo-comp to do anyways)");
             continue;
         }
 
         info!("TRACING block {block_number} with Base. It has {tx_count} transactions");
+        let base_trace_result = if redo_traces || !base_trace_path(block_number).exists() {
+            base_juno.trace_block(block_number).await
+        } else {
+            Ok(read_base_trace(block_number).await)
+        };
+
         // First branch is a succesful block trace with Base
         // Second branch is an unexpected crash by Juno/Blockifier/nNative
-        match base_juno.trace_block(block_number).await {
+        match base_trace_result {
             Ok(base_report) => {
                 if base_report.result != TraceResult::Success {
                     // todo: prettier handling, but low prio.
@@ -134,7 +102,8 @@ async fn execute_traces(
                         ) {
                             warn!("Error writing transaction dependencies: {e:?}");
                         }
-                        log_trace_comparison(block_number, base_report, native_report).await;
+                        let comparison = generate_block_comparison(base_report, native_report);
+                        log_comparison_report(block_number, comparison).await;
                     }
                     Ok(native_report) => {
                         // When tracing a block with native fails, the next step is performing a
@@ -162,34 +131,25 @@ async fn execute_traces(
                                     "Completed block {block_number} with {successes}/{} successes",
                                     result.len()
                                 );
-                                log_block_report(block_number, result);
+                                log_crash_report(block_number, result);
                             }
                             Err(err) => error!("Error simulating transactions: {}", err),
                         };
                     }
                     Err(err) => {
                         warn!("{err:?}");
-                        log_trace_crash(block_number, err).await;
+                        log_unexpected_error_report(block_number, err).await;
                     }
                 };
             }
             Err(err) => {
                 warn!("{err:?}");
-                log_trace_crash(block_number, err).await;
+                log_unexpected_error_report(block_number, err).await;
             }
         }
     }
 
     Ok(())
-}
-
-async fn prepare_directories() {
-    info!("Preparing directories");
-
-    tokio::fs::create_dir_all("./results").await.unwrap();
-    tokio::fs::create_dir_all("./cache").await.unwrap();
-    tokio::fs::create_dir_all("./results/base").await.unwrap();
-    tokio::fs::create_dir_all("./results/native").await.unwrap();
 }
 
 #[tokio::main]
@@ -199,7 +159,9 @@ async fn main() -> Result<(), ManagerError> {
 
     let cli = Cli::parse();
 
-    let run_known = cli.run_known;
+    let redo_comparison = cli.redo_comp;
+
+    let redo_base_trace = cli.redo_base_trace;
 
     let mut simulation_flags = vec![];
 
@@ -217,13 +179,27 @@ async fn main() -> Result<(), ManagerError> {
         Commands::Block { block_num } => {
             let start_block = block_num;
             let end_block = block_num + 1;
-            execute_traces(start_block, end_block, run_known, simulation_flags).await?;
+            execute_traces(
+                start_block,
+                end_block,
+                redo_comparison,
+                redo_base_trace,
+                simulation_flags,
+            )
+            .await?;
         }
         Commands::Range {
             start_block_num,
             end_block_num,
         } => {
-            execute_traces(start_block_num, end_block_num, run_known, simulation_flags).await?;
+            execute_traces(
+                start_block_num,
+                end_block_num,
+                redo_comparison,
+                redo_base_trace,
+                simulation_flags,
+            )
+            .await?;
         }
     }
 

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -72,7 +72,7 @@ impl TransactionSimulator for JunoManager {
         for (i, transaction) in block.transactions().iter().enumerate() {
             let tx_hash = get_block_transaction_hash(transaction);
             debug!(
-                "({}/{max_transaction}) Receipt for 0x{}...",
+                "({}/{max_transaction}) Receipt for 0x{}",
                 i + 1,
                 hash_to_hex(&tx_hash)
             );

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -71,7 +71,11 @@ impl TransactionSimulator for JunoManager {
         let max_transaction = block.transactions().len();
         for (i, transaction) in block.transactions().iter().enumerate() {
             let tx_hash = get_block_transaction_hash(transaction);
-            debug!("({}/{max_transaction}) Receipt for {tx_hash}...", i + 1);
+            debug!(
+                "({}/{max_transaction}) Receipt for 0x{}...",
+                i + 1,
+                hash_to_hex(&tx_hash)
+            );
             let expected_result = self
                 .rpc_client
                 .get_transaction_receipt(tx_hash)

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use log::{info, warn};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use starknet::{
     core::types::{FieldElement, StarknetError},
@@ -10,7 +10,7 @@ use starknet::{
 
 use crate::juno_manager::{JunoBranch, JunoManager, ManagerError};
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TraceResult {
     Success,
     OtherError(String),


### PR DESCRIPTION
Mostly a refactor so that IO operations are located in the same file (previously they were located across two scripts). Also, remove all manual writing of paths and wrapped them inside functions.

Finally added cache mechanisms for when the base trace has been calculated (and since it shouldn't change ever again) there is no need to re-calculate it into the future.
