### PR TITLE
feat: add broadcast tx conversion for deploy account transactions + skip L1 handler tx

### DIFF
--- a/src/juno_manager.rs
+++ b/src/juno_manager.rs
@@ -35,6 +35,7 @@ pub enum ManagerError {
     Provider(ProviderError),
     Internal(String),
     IO(std::io::Error),
+    L1HandlerTransaction,
 }
 
 impl From<ProviderError> for ManagerError {
@@ -55,6 +56,7 @@ impl Display for ManagerError {
             ManagerError::Provider(err) => write!(f, "Manager error: {}", err),
             ManagerError::Internal(err) => write!(f, "Internal error: {}", err),
             ManagerError::IO(err) => write!(f, "IO error: {}", err),
+            ManagerError::L1HandlerTransaction => write!(f, "L1HandlerTransaction"),
         }
     }
 }

--- a/src/juno_manager.rs
+++ b/src/juno_manager.rs
@@ -35,6 +35,7 @@ pub enum ManagerError {
     Provider(ProviderError),
     Internal(String),
     IO(std::io::Error),
+    /// L1HandlerTransaction is not handled yet
     L1HandlerTransaction,
 }
 

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -157,6 +157,7 @@ impl TransactionSimulator for JunoManager {
             let tx_to_simulate = &transactions[i];
             let simulated_result = if tx_to_simulate.tx.is_none() {
                 // This transaction was not simulated, so there is no simulation result
+                // Currently, this will only happen for L1Handler transactions
                 TransactionResult::L1Handler
             } else if i < simulation_results.len() {
                 let result =

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -75,9 +75,7 @@ impl TransactionSimulator for JunoManager {
         let max_transaction = block.transactions().len();
         let block_id = match block {
             MaybePendingBlockWithTxs::Block(block) => BlockId::Number(block.block_number),
-            MaybePendingBlockWithTxs::PendingBlock(_) => {
-                BlockId::Tag(BlockTag::Pending)
-            }
+            MaybePendingBlockWithTxs::PendingBlock(_) => BlockId::Tag(BlockTag::Pending),
         };
 
         for (i, transaction) in block.transactions().iter().enumerate() {
@@ -87,6 +85,10 @@ impl TransactionSimulator for JunoManager {
                 i + 1,
                 hash_to_hex(&tx_hash)
             );
+            if let Transaction::L1Handler(_) = transaction {
+                debug!("Skipping L1Handler transaction simulation, {:?}", tx_hash);
+                continue;
+            }
             let expected_result = self
                 .rpc_client
                 .get_transaction_receipt(tx_hash)

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -430,11 +430,6 @@ pub enum TransactionResult {
     Revert { reason: String },
     Crash,
     Unreached,
-
-    // TEMP
-    DeployAccount,
-    L1Handler,
-    Declare,
 }
 
 // To be used when outputting in json format
@@ -445,11 +440,6 @@ impl Display for TransactionResult {
             TransactionResult::Revert { reason } => write!(f, "Reverted: {}", reason),
             TransactionResult::Crash => write!(f, "Crash"),
             TransactionResult::Unreached => write!(f, "Unreached"),
-            TransactionResult::DeployAccount => {
-                write!(f, "TODO determine success of deploy account transactions")
-            }
-            TransactionResult::L1Handler => write!(f, "L1Handler transactions not handled yet"),
-            TransactionResult::Declare => write!(f, "Declare transactions not handled yet"),
         }
     }
 }
@@ -627,8 +617,8 @@ fn get_simulated_transaction_result(transaction: &SimulatedTransaction) -> Trans
                 reason: tx.revert_reason.clone(),
             },
         },
-        TransactionTrace::DeployAccount(_) => TransactionResult::DeployAccount,
-        TransactionTrace::L1Handler(_) => TransactionResult::L1Handler,
-        TransactionTrace::Declare(_) => TransactionResult::Declare,
+        TransactionTrace::DeployAccount(_) => TransactionResult::Success,
+        TransactionTrace::L1Handler(_) => TransactionResult::Success,
+        TransactionTrace::Declare(_) => TransactionResult::Success,
     }
 }

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -428,13 +428,13 @@ async fn block_transaction_to_broadcasted_transaction(
         Transaction::L1Handler(_) => Err(ManagerError::L1HandlerTransaction)?,
         Transaction::Declare(declare_transaction) => {
             Ok(BroadcastedTransaction::Declare(match declare_transaction {
-                DeclareTransaction::V0(_) => Err(ManagerError::Internal(String::from("V0")))?,
+                DeclareTransaction::V0(_) => Err(ManagerError::Internal("V0".to_string()))?,
                 DeclareTransaction::V1(tx) => {
                     let contract_class = juno_manager
                         .rpc_client
                         .get_class(block_id, tx.class_hash)
                         .await
-                        .map_err(|_| ManagerError::Internal(String::from("class not found")))?;
+                        .map_err(|_| ManagerError::Internal("class not found".to_string()))?;
                     match contract_class {
                         ContractClass::Legacy(contract_class) => {
                             BroadcastedDeclareTransaction::V1(BroadcastedDeclareTransactionV1 {
@@ -446,9 +446,9 @@ async fn block_transaction_to_broadcasted_transaction(
                                 is_query: false,
                             })
                         }
-                        _ => Err(ManagerError::Internal(String::from(
-                            "V1 declare can't find legacy contract class",
-                        )))?,
+                        _ => Err(ManagerError::Internal(
+                            "V1 declare can't find legacy contract class".to_string(),
+                        ))?,
                     }
                 }
                 DeclareTransaction::V2(tx) => {
@@ -456,7 +456,7 @@ async fn block_transaction_to_broadcasted_transaction(
                         .rpc_client
                         .get_class(block_id, tx.class_hash)
                         .await
-                        .map_err(|_| ManagerError::Internal(String::from("class not found")))?;
+                        .map_err(|_| ManagerError::Internal("class not found".to_string()))?;
                     match contract_class {
                         ContractClass::Sierra(contract_class) => {
                             BroadcastedDeclareTransaction::V2(BroadcastedDeclareTransactionV2 {
@@ -469,9 +469,9 @@ async fn block_transaction_to_broadcasted_transaction(
                                 is_query: false,
                             })
                         }
-                        _ => Err(ManagerError::Internal(String::from(
-                            "V2 declare can't find sierra contract class",
-                        )))?,
+                        _ => Err(ManagerError::Internal(
+                            "V2 declare can't find sierra contract class".to_string(),
+                        ))?,
                     }
                 }
                 DeclareTransaction::V3(tx) => {
@@ -479,7 +479,7 @@ async fn block_transaction_to_broadcasted_transaction(
                         .rpc_client
                         .get_class(block_id, tx.class_hash)
                         .await
-                        .map_err(|_| ManagerError::Internal(String::from("class not found")))?;
+                        .map_err(|_| ManagerError::Internal("class not found".to_string()))?;
                     match contract_class {
                         ContractClass::Sierra(contract_class) => {
                             BroadcastedDeclareTransaction::V3(BroadcastedDeclareTransactionV3 {
@@ -497,9 +497,9 @@ async fn block_transaction_to_broadcasted_transaction(
                                 is_query: false,
                             })
                         }
-                        _ => Err(ManagerError::Internal(String::from(
-                            "V3 declare can't find sierra contract class",
-                        )))?,
+                        _ => Err(ManagerError::Internal(
+                            "V3 declare can't find sierra contract class".to_string(),
+                        ))?,
                     }
                 }
             }))

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -96,6 +96,7 @@ impl TransactionSimulator for JunoManager {
                     .await
                 {
                     Ok(tx) => Some(tx),
+                    // Remove this once we have a way to handle L1Handler transactions
                     Err(ManagerError::L1HandlerTransaction) => None,
                     Err(e) => return Err(e),
                 };

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -430,6 +430,11 @@ pub enum TransactionResult {
     Revert { reason: String },
     Crash,
     Unreached,
+
+    // TEMP
+    DeployAccount,
+    L1Handler,
+    Declare,
 }
 
 // To be used when outputting in json format
@@ -440,6 +445,11 @@ impl Display for TransactionResult {
             TransactionResult::Revert { reason } => write!(f, "Reverted: {}", reason),
             TransactionResult::Crash => write!(f, "Crash"),
             TransactionResult::Unreached => write!(f, "Unreached"),
+            TransactionResult::DeployAccount => {
+                write!(f, "TODO determine success of deploy account transactions")
+            }
+            TransactionResult::L1Handler => write!(f, "L1Handler transactions not handled yet"),
+            TransactionResult::Declare => write!(f, "Declare transactions not handled yet"),
         }
     }
 }
@@ -617,8 +627,8 @@ fn get_simulated_transaction_result(transaction: &SimulatedTransaction) -> Trans
                 reason: tx.revert_reason.clone(),
             },
         },
-        TransactionTrace::DeployAccount(_) => TransactionResult::Success,
-        TransactionTrace::L1Handler(_) => TransactionResult::Success,
-        TransactionTrace::Declare(_) => TransactionResult::Success,
+        TransactionTrace::DeployAccount(_) => TransactionResult::DeployAccount,
+        TransactionTrace::L1Handler(_) => TransactionResult::L1Handler,
+        TransactionTrace::Declare(_) => TransactionResult::Declare,
     }
 }

--- a/src/transaction_simulator.rs
+++ b/src/transaction_simulator.rs
@@ -9,9 +9,8 @@ use serde::Serialize;
 use starknet::core::types::{
     BlockTag, BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV1,
     BroadcastedDeclareTransactionV2, BroadcastedDeclareTransactionV3, ContractClass,
-    SimulationFlag, StarknetError,
+    SimulationFlag,
 };
-use starknet::providers::ProviderError;
 use starknet::{
     core::types::{
         BlockId, BroadcastedDeployAccountTransaction, BroadcastedDeployAccountTransactionV1,
@@ -76,7 +75,7 @@ impl TransactionSimulator for JunoManager {
         let max_transaction = block.transactions().len();
         let block_id = match block {
             MaybePendingBlockWithTxs::Block(block) => BlockId::Number(block.block_number),
-            MaybePendingBlockWithTxs::PendingBlock(pending_block) => {
+            MaybePendingBlockWithTxs::PendingBlock(_) => {
                 BlockId::Tag(BlockTag::Pending)
             }
         };
@@ -95,8 +94,7 @@ impl TransactionSimulator for JunoManager {
                 .into();
 
             result.push(TransactionToSimulate {
-                tx: self
-                    .block_transaction_to_broadcasted_transaction(transaction, block_id)
+                tx: block_transaction_to_broadcasted_transaction(self, transaction, block_id)
                     .await?,
                 hash: tx_hash,
                 expected_result,
@@ -282,149 +280,145 @@ impl TransactionSimulator for JunoManager {
     }
 }
 
-impl JunoManager {
-    async fn block_transaction_to_broadcasted_transaction(
-        &self,
-        transaction: &Transaction,
-        block_id: BlockId,
-    ) -> Result<BroadcastedTransaction, ManagerError> {
-        match transaction {
-            Transaction::Invoke(invoke_transaction) => match invoke_transaction {
-                InvokeTransaction::V0(_) => {
-                    Err(ManagerError::InternalError("V0 invoke".to_string()))
-                }
-                InvokeTransaction::V1(tx) => Ok(BroadcastedTransaction::Invoke(
-                    BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
-                        sender_address: tx.sender_address,
-                        calldata: tx.calldata.clone(),
-                        max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
-                        nonce: tx.nonce,
-                        is_query: false,
-                    }),
-                )),
-                InvokeTransaction::V3(tx) => Ok(BroadcastedTransaction::Invoke(
-                    BroadcastedInvokeTransaction::V3(BroadcastedInvokeTransactionV3 {
-                        sender_address: tx.sender_address,
-                        calldata: tx.calldata.clone(),
-                        signature: tx.signature.clone(),
-                        nonce: tx.nonce,
-                        resource_bounds: tx.resource_bounds.clone(),
-                        tip: tx.tip,
-                        paymaster_data: tx.paymaster_data.clone(),
-                        account_deployment_data: tx.account_deployment_data.clone(),
-                        nonce_data_availability_mode: tx.nonce_data_availability_mode,
-                        fee_data_availability_mode: tx.fee_data_availability_mode,
-                        is_query: false,
-                    }),
-                )),
-            },
-            Transaction::L1Handler(_) => Err(ManagerError::InternalError("L1Handler".to_string())),
-            Transaction::Declare(declare_transaction) => {
-                Ok(BroadcastedTransaction::Declare(match declare_transaction {
-                    DeclareTransaction::V0(_) => panic!("V0"),
-                    DeclareTransaction::V1(tx) => {
-                        let contract_class = self
-                            .rpc_client
-                            .get_class(block_id, tx.class_hash)
-                            .await
-                            .map_err(|_| {
-                                ManagerError::InternalError(String::from("class not found"))
-                            })?;
-                        if let ContractClass::Legacy(contract_class) = contract_class {
-                            BroadcastedDeclareTransaction::V1(BroadcastedDeclareTransactionV1 {
-                                sender_address: tx.sender_address,
-                                max_fee: tx.max_fee,
-                                signature: tx.signature.clone(),
-                                nonce: tx.nonce,
-                                contract_class: Arc::new(contract_class),
-                                is_query: false,
-                            })
-                        } else {
-                            panic!("V1 declare can't find legacy contract class")
-                        }
+async fn block_transaction_to_broadcasted_transaction(
+    juno_manager: &JunoManager,
+    transaction: &Transaction,
+    block_id: BlockId,
+) -> Result<BroadcastedTransaction, ManagerError> {
+    match transaction {
+        Transaction::Invoke(invoke_transaction) => match invoke_transaction {
+            InvokeTransaction::V0(_) => Err(ManagerError::InternalError("V0 invoke".to_string())),
+            InvokeTransaction::V1(tx) => Ok(BroadcastedTransaction::Invoke(
+                BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1 {
+                    sender_address: tx.sender_address,
+                    calldata: tx.calldata.clone(),
+                    max_fee: tx.max_fee,
+                    signature: tx.signature.clone(),
+                    nonce: tx.nonce,
+                    is_query: false,
+                }),
+            )),
+            InvokeTransaction::V3(tx) => Ok(BroadcastedTransaction::Invoke(
+                BroadcastedInvokeTransaction::V3(BroadcastedInvokeTransactionV3 {
+                    sender_address: tx.sender_address,
+                    calldata: tx.calldata.clone(),
+                    signature: tx.signature.clone(),
+                    nonce: tx.nonce,
+                    resource_bounds: tx.resource_bounds.clone(),
+                    tip: tx.tip,
+                    paymaster_data: tx.paymaster_data.clone(),
+                    account_deployment_data: tx.account_deployment_data.clone(),
+                    nonce_data_availability_mode: tx.nonce_data_availability_mode,
+                    fee_data_availability_mode: tx.fee_data_availability_mode,
+                    is_query: false,
+                }),
+            )),
+        },
+        Transaction::L1Handler(_) => Err(ManagerError::InternalError("L1Handler".to_string())),
+        Transaction::Declare(declare_transaction) => {
+            Ok(BroadcastedTransaction::Declare(match declare_transaction {
+                DeclareTransaction::V0(_) => panic!("V0"),
+                DeclareTransaction::V1(tx) => {
+                    let contract_class = juno_manager
+                        .rpc_client
+                        .get_class(block_id, tx.class_hash)
+                        .await
+                        .map_err(|_| {
+                            ManagerError::InternalError(String::from("class not found"))
+                        })?;
+                    if let ContractClass::Legacy(contract_class) = contract_class {
+                        BroadcastedDeclareTransaction::V1(BroadcastedDeclareTransactionV1 {
+                            sender_address: tx.sender_address,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature.clone(),
+                            nonce: tx.nonce,
+                            contract_class: Arc::new(contract_class),
+                            is_query: false,
+                        })
+                    } else {
+                        panic!("V1 declare can't find legacy contract class")
                     }
-                    DeclareTransaction::V2(tx) => {
-                        let contract_class = self
-                            .rpc_client
-                            .get_class(block_id, tx.class_hash)
-                            .await
-                            .map_err(|_| {
-                                ManagerError::InternalError(String::from("class not found"))
-                            })?;
-                        if let ContractClass::Sierra(contract_class) = contract_class {
-                            BroadcastedDeclareTransaction::V2(BroadcastedDeclareTransactionV2 {
-                                sender_address: tx.sender_address,
-                                max_fee: tx.max_fee,
-                                signature: tx.signature.clone(),
-                                nonce: tx.nonce,
-                                compiled_class_hash: tx.compiled_class_hash,
-                                contract_class: Arc::new(contract_class),
-                                is_query: false,
-                            })
-                        } else {
-                            panic!("V2 declare can't find sierra contract class")
-                        }
-                    }
-                    DeclareTransaction::V3(tx) => {
-                        let contract_class = self
-                            .rpc_client
-                            .get_class(block_id, tx.class_hash)
-                            .await
-                            .map_err(|_| {
-                                ManagerError::InternalError(String::from("class not found"))
-                            })?;
-                        if let ContractClass::Sierra(contract_class) = contract_class {
-                            BroadcastedDeclareTransaction::V3(BroadcastedDeclareTransactionV3 {
-                                sender_address: tx.sender_address,
-                                signature: tx.signature.clone(),
-                                nonce: tx.nonce,
-                                compiled_class_hash: tx.compiled_class_hash,
-                                contract_class: Arc::new(contract_class),
-                                account_deployment_data: tx.account_deployment_data.clone(),
-                                fee_data_availability_mode: tx.fee_data_availability_mode,
-                                nonce_data_availability_mode: tx.nonce_data_availability_mode,
-                                paymaster_data: tx.paymaster_data.clone(),
-                                resource_bounds: tx.resource_bounds.clone(),
-                                tip: tx.tip,
-                                is_query: false,
-                            })
-                        } else {
-                            panic!("V3 declare can't find sierra contract class")
-                        }
-                    }
-                }))
-            }
-            Transaction::Deploy(_) => Err(ManagerError::InternalError("Deploy".to_string())),
-            Transaction::DeployAccount(tx) => Ok(BroadcastedTransaction::DeployAccount(match tx {
-                DeployAccountTransaction::V1(tx) => {
-                    BroadcastedDeployAccountTransaction::V1(BroadcastedDeployAccountTransactionV1 {
-                        max_fee: tx.max_fee,
-                        signature: tx.signature.clone(),
-                        nonce: tx.nonce,
-                        contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: tx.constructor_calldata.clone(),
-                        class_hash: tx.class_hash,
-                        is_query: false,
-                    })
                 }
-                DeployAccountTransaction::V3(tx) => {
-                    BroadcastedDeployAccountTransaction::V3(BroadcastedDeployAccountTransactionV3 {
-                        signature: tx.signature.clone(),
-                        nonce: tx.nonce,
-                        contract_address_salt: tx.contract_address_salt,
-                        constructor_calldata: tx.constructor_calldata.clone(),
-                        class_hash: tx.class_hash,
-                        resource_bounds: tx.resource_bounds.clone(),
-                        tip: tx.tip,
-                        paymaster_data: tx.paymaster_data.clone(),
-                        nonce_data_availability_mode: tx.nonce_data_availability_mode,
-                        fee_data_availability_mode: tx.fee_data_availability_mode,
-                        is_query: false,
-                    })
+                DeclareTransaction::V2(tx) => {
+                    let contract_class = juno_manager
+                        .rpc_client
+                        .get_class(block_id, tx.class_hash)
+                        .await
+                        .map_err(|_| {
+                            ManagerError::InternalError(String::from("class not found"))
+                        })?;
+                    if let ContractClass::Sierra(contract_class) = contract_class {
+                        BroadcastedDeclareTransaction::V2(BroadcastedDeclareTransactionV2 {
+                            sender_address: tx.sender_address,
+                            max_fee: tx.max_fee,
+                            signature: tx.signature.clone(),
+                            nonce: tx.nonce,
+                            compiled_class_hash: tx.compiled_class_hash,
+                            contract_class: Arc::new(contract_class),
+                            is_query: false,
+                        })
+                    } else {
+                        panic!("V2 declare can't find sierra contract class")
+                    }
                 }
-            })),
+                DeclareTransaction::V3(tx) => {
+                    let contract_class = juno_manager
+                        .rpc_client
+                        .get_class(block_id, tx.class_hash)
+                        .await
+                        .map_err(|_| {
+                            ManagerError::InternalError(String::from("class not found"))
+                        })?;
+                    if let ContractClass::Sierra(contract_class) = contract_class {
+                        BroadcastedDeclareTransaction::V3(BroadcastedDeclareTransactionV3 {
+                            sender_address: tx.sender_address,
+                            signature: tx.signature.clone(),
+                            nonce: tx.nonce,
+                            compiled_class_hash: tx.compiled_class_hash,
+                            contract_class: Arc::new(contract_class),
+                            account_deployment_data: tx.account_deployment_data.clone(),
+                            fee_data_availability_mode: tx.fee_data_availability_mode,
+                            nonce_data_availability_mode: tx.nonce_data_availability_mode,
+                            paymaster_data: tx.paymaster_data.clone(),
+                            resource_bounds: tx.resource_bounds.clone(),
+                            tip: tx.tip,
+                            is_query: false,
+                        })
+                    } else {
+                        panic!("V3 declare can't find sierra contract class")
+                    }
+                }
+            }))
         }
+        Transaction::Deploy(_) => Err(ManagerError::InternalError("Deploy".to_string())),
+        Transaction::DeployAccount(tx) => Ok(BroadcastedTransaction::DeployAccount(match tx {
+            DeployAccountTransaction::V1(tx) => {
+                BroadcastedDeployAccountTransaction::V1(BroadcastedDeployAccountTransactionV1 {
+                    max_fee: tx.max_fee,
+                    signature: tx.signature.clone(),
+                    nonce: tx.nonce,
+                    contract_address_salt: tx.contract_address_salt,
+                    constructor_calldata: tx.constructor_calldata.clone(),
+                    class_hash: tx.class_hash,
+                    is_query: false,
+                })
+            }
+            DeployAccountTransaction::V3(tx) => {
+                BroadcastedDeployAccountTransaction::V3(BroadcastedDeployAccountTransactionV3 {
+                    signature: tx.signature.clone(),
+                    nonce: tx.nonce,
+                    contract_address_salt: tx.contract_address_salt,
+                    constructor_calldata: tx.constructor_calldata.clone(),
+                    class_hash: tx.class_hash,
+                    resource_bounds: tx.resource_bounds.clone(),
+                    tip: tx.tip,
+                    paymaster_data: tx.paymaster_data.clone(),
+                    nonce_data_availability_mode: tx.nonce_data_availability_mode,
+                    fee_data_availability_mode: tx.fee_data_availability_mode,
+                    is_query: false,
+                })
+            }
+        })),
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/NethermindEth/blockifier-tester/issues/59

## Changes

- modify `TransactionToSimulate` to use `Option<BroadcastedTransaction>` instead, which will not be sent to the RPC for simulation
  - currently only for `L1Handler` transactions
  - when L1 handler transactions are supported in the future, `block_transaction_to_broadcasted_transaction` can simply update the conversion to not return `ManagerError::L1HandlerTransaction`, without modifying anything else
- update transaction to broadcasted transaction logic to support `DeclareTransaction`s, which require another RPC call to retrieve the `contract_class` value based off of the `class_hash`

## Examples

For block `642265` (which currently crashes), the `L1Handler` transaction now looks like this

```json
{
  {
    "contract_dependencies": "Not found",
    "expected_result": "Success",
    "simulated_result": "L1Handler",
    "storage_dependencies": "Not found",
    "tx_hash": "0x1294b3ca121af15ddc7e9ee01d16ca0c90189eccfe87f7e1460d614e51669c9"
  },
}
```
Tested `DEPLOY_ACCOUNT` v1 and v3 in block `640092`, it appears to be working where there are 3 `Same(DEPLOY_ACCOUNT)` instances.

## Other solutions

1. adding a boolean `is_l1_handler` to `TransactionToSimulate`, so that we can check this field in `simulate_block` on top of doing an `is_none()` check
  - felt that this is unnecessary. in the event that L1 handler is supported in the future, the current solution would work by modifying `block_transaction_to_broadcasted_transaction`. this solution would require the removal of this boolean
2. update `block_transaction_to_broadcasted_transaction` to return an `Option<BroadcastedTransaction>`
  - similar to 1., I feel this logic would make it harder for future migration, and out of place for a marshalling / conversion method
  - the current solution is basically equivalent to this, without modifying the API of `block_transaction_to_broadcasted_transaction`
3. update `get_transactions_to_simulate` to return `Result<Vec<Option<TransactionToSimulate>>, ManagerError>`
  - doing this strips away the other fields in `TransactionToSimulate` that is being used in block simulation, i.e. `hash` and `expected_result`, which may be used by other consumers, even if the transaction was not sent to RPC for simulation
