### PR TITLE
feat: remove redundant fields in trace when trace is correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ native_juno_out.log
 .vscode/
 .idea/
 .DS_Store
+results

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ native_juno_out.log
 .vscode/
 .idea/
 .DS_Store
-results

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn execute_traces(
             continue;
         }
 
-        let base_trace_result =
+        let mut base_trace_result =
             trace_base(redo_traces, block_number, tx_count, &mut base_juno).await?;
 
         info!("Switching from Base Juno to Native Juno");
@@ -75,9 +75,9 @@ async fn execute_traces(
         info!("TRACING block {block_number} with Native. It has {tx_count} transactions");
         let native_trace = trace_native(block_number, tx_count, &simulation_flags).await?;
 
-        if let Some(native_trace) = native_trace {
+        if let Some(mut native_trace) = native_trace {
             let comparison =
-                generate_block_comparison(block_number, base_trace_result, native_trace);
+                generate_block_comparison(block_number, &mut base_trace_result, &mut native_trace);
             log_comparison_report(block_number, comparison).await;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use juno_manager::{JunoBranch, JunoManager, ManagerError};
 use log::{error, info, warn};
 use starknet::core::types::{SimulationFlag, TransactionTraceWithHash};
 use std::io::Write;
-use trace_comparison::{generate_block_comparison, tidy_trace_roots};
+use trace_comparison::generate_block_comparison;
 use transaction_simulator::{SimulationStrategy, TransactionSimulator};
 use transaction_tracer::TraceResult;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use juno_manager::{JunoBranch, JunoManager, ManagerError};
 use log::{error, info, warn};
 use starknet::core::types::{SimulationFlag, TransactionTraceWithHash};
 use std::io::Write;
-use trace_comparison::generate_block_comparison;
+use trace_comparison::{generate_block_comparison, tidy_trace_roots};
 use transaction_simulator::{SimulationStrategy, TransactionSimulator};
 use transaction_tracer::TraceResult;
 

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -106,8 +106,8 @@ pub fn generate_block_comparison(
     base_traces: Vec<TransactionTraceWithHash>,
     native_traces: Vec<TransactionTraceWithHash>,
 ) -> Value {
-    let mut base_traces = base_report.post_response.unwrap_or_default();
-    let mut native_traces = native_report.post_response.unwrap_or_default();
+    let mut base_traces = base_traces.clone();
+    let mut native_traces = native_traces.clone();
 
     normalize_traces_state_diff(&mut base_traces);
     normalize_traces_state_diff(&mut native_traces);
@@ -124,7 +124,7 @@ pub fn generate_block_comparison(
     }
 
     json!({
-        "block_num": base_report.block_num,
+        "block_num": block_number,
         "post_response": post_response,
     })
 }

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -109,13 +109,14 @@ pub fn generate_block_comparison(
     let base_block_report = block_report_with_dependencies(&base_traces);
     let native_block_report = block_report_with_dependencies(&native_traces);
 
-    let mut post_response = vec![];
-
-    if let (Value::Array(base), Value::Array(native)) = (&base_block_report, &native_block_report) {
-        for (base_trace, native_trace) in base.iter().zip(native.iter()) {
-            post_response.push(compare_trace(base_trace, native_trace));
-        }
-    }
+    let post_response = match (&base_block_report, &native_block_report) {
+        (Value::Array(base), Value::Array(native)) => base
+            .iter()
+            .zip(native.iter())
+            .map(|(base_trace, native_trace)| compare_trace(base_trace, native_trace))
+            .collect(),
+        _ => Vec::new(),
+    };
 
     json!({
         "block_num": block_number,

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, VecDeque},
-};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -266,9 +263,8 @@ fn compare_trace(base_trace: &Value, native_trace: &Value) -> Value {
         base_trace["trace_root"].clone(),
         native_trace["trace_root"].clone(),
     );
-    let is_different = contains_key(&trace_root_comparison, &String::from("Different"));
 
-    if !is_different {
+    if value_is_same(&trace_root_comparison) {
         json!({
             "transaction_hash": base_trace["transaction_hash"],
             "trace_root": "Same",
@@ -281,34 +277,6 @@ fn compare_trace(base_trace: &Value, native_trace: &Value) -> Value {
             "storage_dependencies": compare_jsons(base_trace["storage_dependencies"].clone(), native_trace["storage_dependencies"].clone()),
         })
     }
-}
-
-/// BFS to check whether target key is present in JSON object
-fn contains_key(object: &Value, target_key: &String) -> bool {
-    let mut queue = VecDeque::new();
-    queue.push_back(object);
-
-    while let Some(current_object) = queue.pop_front() {
-        if let Some(map) = current_object.as_object() {
-            for (key, value) in map {
-                if key.cmp(target_key) == Ordering::Equal {
-                    return true;
-                }
-
-                if value.is_object() {
-                    queue.push_back(value);
-                } else if value.is_array() {
-                    for item in value.as_array().unwrap() {
-                        if item.is_object() {
-                            queue.push_back(item);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    false
 }
 
 fn clean_json_value(val: Value) -> Value {

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -711,7 +711,7 @@ mod tests {
             result,
             json!({
                 "trace_root": "Same",
-                "transaction_hash": "Same(0x2b843f740cfcc46d581299e3b3353008d8025aa9973fb8506caf6e8daa1d8c9)"
+                "transaction_hash": "0x2b843f740cfcc46d581299e3b3353008d8025aa9973fb8506caf6e8daa1d8c9"
             })
         );
 
@@ -771,7 +771,7 @@ mod tests {
                         "calls": "Same([1])"
                     }
                 },
-                "transaction_hash": "Same(0x2b843f740cfcc46d581299e3b3353008d8025aa9973fb8506caf6e8daa1d8c9)"
+                "transaction_hash": "0x2b843f740cfcc46d581299e3b3353008d8025aa9973fb8506caf6e8daa1d8c9"
             })
         );
     }

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -137,9 +137,10 @@ pub fn tidy_trace_roots(comparison_report: Value) -> Value {
     })
 }
 
-fn contains_key(trace_root: &Value, target_key: &String) -> bool {
+// BFS to check whether target key is present in JSON object
+fn contains_key(object: &Value, target_key: &String) -> bool {
     let mut queue = VecDeque::new();
-    queue.push_back(trace_root);
+    queue.push_back(object);
 
     while let Some(current_object) = queue.pop_front() {
         if let Some(map) = current_object.as_object() {
@@ -150,6 +151,10 @@ fn contains_key(trace_root: &Value, target_key: &String) -> bool {
 
                 if value.is_object() {
                     queue.push_back(value);
+                } else if value.is_array() {
+                    for item in value.as_array().unwrap() {
+                        queue.push_back(item);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Goal 

- avoid comparing some obvious fields, i.e. `block_num`, `transaction_hash`
- main concern is the comparison of `trace_root`, so if the outcome is "Same", we ignore the comparison of some fields, i.e. `contract_dependencies`, `storage_dependencies`

If the trace root is Same:
```json
{
  "block_num": "6333333", // instead of "Same(633333)"
  "post_response": [
    {
      "trace_root": "Same({n})"
      "transaction_hash": "some_hash", // instead of "Same(some_hash)"
    },
    {
      "trace_root": "Same({n})"
      "transaction_hash": "some_other_hash",
    }
  ]
}
```
If the trace root is Different:
```json
{
  "block_num": "633333",
  "post_response": [
    {
      "contract_dependencies": [
          // Different {... }, Same, etc...,
      ],
      "storage_dependencies": "Same([2])",
      "trace_root": {
        "execute_invocation": {
          "call_type": "Same(CALL)",
          "calldata": "Same([8])",
          // There is something **Different** down the line
        }
      }
      "transaction_hash": "some_hash",
    }
  ]
}
```

## Changes

- update block simulation report to compare `trace_root` first, in each element in `post_response`
  - if `trace_root` is same, we return comparison of `trace_root` and `transaction_hash` without comparison
  - otherwise, we additionally return the comparison of `contract_dependencies` and `storage_dependencies`
  - this logic is encapsulated in `compare_trace` method
- add unit test for `compare_trace`

## Other solutions

1. do the comparison first for every trace, then remove the extra fields, i.e. `contract_dependencies` and `storage_dependencies`
  - this was the initial solution. however, this is inefficient as we would still be comparing these additional fields, which goes against the goal 