### PR TITLE
feat: parallel preparation 

### DIFF
--- a/src/block_tracer.rs
+++ b/src/block_tracer.rs
@@ -7,8 +7,7 @@ use crate::{
     transaction_tracer::TraceResult,
 };
 
-// todo(xrvdg) try to get rid of clone
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TraceBlockReport {
     pub block_num: u64,
     pub result: TraceResult,

--- a/src/block_tracer.rs
+++ b/src/block_tracer.rs
@@ -1,19 +1,16 @@
 use log::debug;
 use serde::{Deserialize, Serialize};
-use starknet::{
-    core::types::{BlockId, TransactionTraceWithHash},
-    providers::Provider,
-};
+use starknet::{core::types::BlockId, providers::Provider};
 
 use crate::{
     juno_manager::{JunoManager, ManagerError},
     transaction_tracer::TraceResult,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+// todo(xrvdg) try to get rid of clone
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceBlockReport {
     pub block_num: u64,
-    pub post_response: Option<Vec<TransactionTraceWithHash>>,
     pub result: TraceResult,
 }
 
@@ -33,15 +30,13 @@ impl BlockTracer for JunoManager {
         match trace_result {
             Ok(trace_result) => Ok(TraceBlockReport {
                 block_num,
-                result: TraceResult::Success,
-                post_response: Some(trace_result),
+                result: TraceResult::Success(trace_result),
             }),
             Err(provider_error) => Ok(TraceBlockReport {
                 block_num,
                 result: TraceResult::Crash {
                     error: provider_error.to_string(),
                 },
-                post_response: None,
             }),
         }
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -59,7 +59,7 @@ pub fn log_crash_report(block_number: u64, report: serde_json::Value) {
 }
 
 // Creates a file in ./results/crash-{`block_number`}.json with the failure reason
-pub async fn log_unexpected_error_report(block_number: u64, err: ManagerError) {
+pub async fn log_unexpected_error_report(block_number: u64, err: &ManagerError) {
     let mut log_file = AsyncOpenOptions::new()
         .create(true)
         .write(true)

--- a/src/io.rs
+++ b/src/io.rs
@@ -93,8 +93,6 @@ pub fn log_base_trace(block_number: u64, trace: &Vec<TransactionTraceWithHash>) 
 /// Returns None if no valid cached base trace is found.
 /// todo(xrvdg) convert to result once blockifier has been parallelized?
 pub fn read_base_trace(block_number: u64) -> Option<Vec<TransactionTraceWithHash>> {
-    info!("Reading cached trace for block {block_number}");
-
     let block_file = OpenOptions::new()
         .read(true)
         .open(base_trace_path(block_number))

--- a/src/io.rs
+++ b/src/io.rs
@@ -96,15 +96,21 @@ pub async fn log_base_trace(block_number: u64, trace: Vec<TransactionTraceWithHa
     .unwrap_or_else(|_| panic!("failed to write block: {block_number}"));
 }
 
-pub async fn read_base_trace(block_number: u64) -> TraceBlockReport {
-    info!("Reading cached trace for block {block_number}");
+// todo(xrvdg) add version check
+// change name to mention caching
+pub async fn read_base_trace(block_number: u64) -> Option<TraceBlockReport> {
+    if base_trace_path(block_number).exists() {
+        info!("Reading cached trace for block {block_number}");
 
-    let block_file = OpenOptions::new()
-        .read(true)
-        .open(base_trace_path(block_number))
-        .expect("Failed to read base trace");
+        let block_file = OpenOptions::new()
+            .read(true)
+            .open(base_trace_path(block_number))
+            .expect("Failed to read base trace");
 
-    serde_json::from_reader(block_file).expect("Couldn't parse JSON")
+        Some(serde_json::from_reader(block_file).expect("Couldn't parse JSON"))
+    } else {
+        None
+    }
 }
 
 pub async fn prepare_directories() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,10 @@ async fn trace_base(
     };
 
     match base_trace {
-        Some(trace) => Ok(trace),
+        Some(trace) => {
+            info!("Using cached trace for block {block_number}");
+            Ok(trace)
+        }
         None => {
             let base_trace_result = base_juno.trace_block(block_number).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ mod transaction_tracer;
 
 use crate::cli::{Cli, Commands};
 use crate::io::{
-    base_trace_path, crashed_comparison_path, log_base_trace, log_comparison_report,
-    log_crash_report, log_unexpected_error_report, read_base_trace, succesful_comparison_path,
+    crashed_comparison_path, log_base_trace, log_comparison_report, log_crash_report,
+    log_unexpected_error_report, read_base_trace, succesful_comparison_path,
 };
 use block_tracer::BlockTracer;
 use cache::get_sorted_blocks_with_tx_count;
@@ -46,9 +46,7 @@ fn setup_env_logger() {
 
 async fn execute_traces(
     start_block: u64,
-    // end_block should be inclusive
     end_block: u64,
-    // Would be nice to get these bools out
     redo_comparison: bool,
     redo_traces: bool,
     simulation_flags: Vec<SimulationFlag>,
@@ -59,7 +57,6 @@ async fn execute_traces(
             .await
             .unwrap();
 
-    // TODO(xrvdg) make this separate futures
     for (block_number, tx_count) in blocks_with_tx_count {
         if !redo_comparison
             && (succesful_comparison_path(block_number).exists()
@@ -72,8 +69,10 @@ async fn execute_traces(
         let base_trace_result =
             trace_base(redo_traces, block_number, tx_count, &mut base_juno).await?;
 
+        info!("Switching from Base Juno to Native Juno");
         base_juno.ensure_dead().await?;
 
+        info!("TRACING block {block_number} with Native. It has {tx_count} transactions");
         let native_trace = trace_native(block_number, tx_count, &simulation_flags).await?;
 
         if let Some(native_trace) = native_trace {
@@ -86,28 +85,77 @@ async fn execute_traces(
     Ok(())
 }
 
+/// Traces a transaction using base Juno and caches to result to disk.
+///
+/// trace_base will try and read a valid cache from [`io::base_trace_path`] if it exists
+/// otherwise it will trace a block using base Juno.
+///
+/// To force redoing a trace with base Juno set redo_traces to `true`.
+async fn trace_base(
+    redo_traces: bool,
+    block_number: u64,
+    tx_count: u64,
+    base_juno: &mut JunoManager,
+) -> Result<Vec<TransactionTraceWithHash>, ManagerError> {
+    info!("TRACING block {block_number} with Base. It has {tx_count} transactions");
+
+    let base_trace = match redo_traces {
+        true => None,
+        false => read_base_trace(block_number),
+    };
+
+    match base_trace {
+        Some(trace) => Ok(trace),
+        None => {
+            let base_trace_result = base_juno.trace_block(block_number).await;
+
+            // todo(xrvdg) can we lift this out when reworking error?
+            let base_trace_result = match base_trace_result {
+                Ok(b) => Ok(b),
+                Err(err) => {
+                    warn!("{err:?}");
+                    log_unexpected_error_report(block_number, &err).await;
+                    Err(err)
+                }
+            }?;
+
+            match base_trace_result.result {
+                TraceResult::Success(trace) => {
+                    log_base_trace(block_number, &trace);
+                    Ok(trace)
+                }
+
+                base_report => {
+                    // todo: prettier handling, but low prio.
+                    let trace = serde_json::to_string_pretty(&base_report)
+                        .unwrap_or(format!("Serialization failed!\n{base_report:?}"));
+
+                    // todo(xrvdg) remove this panic when moving to parallel execution
+                    panic!("Tracing with base juno is always expected to work. Check your base juno bin and config. Error:\n{}",trace);
+                }
+            }
+        }
+    }
+}
+
 async fn trace_native(
     block_number: u64,
     tx_count: u64,
-    simulation_flags: &Vec<SimulationFlag>,
+    simulation_flags: &[SimulationFlag],
 ) -> Result<Option<Vec<TransactionTraceWithHash>>, ManagerError> {
-    info!("Switching from Base Juno to Native Juno");
-
     let mut native_juno = JunoManager::new(JunoBranch::Native).await?;
 
     let native_trace_result = native_juno.trace_block(block_number).await;
 
+    // todo(xrvdg) can we lift this out when reworking error?
     let native_trace_result = match native_trace_result {
         Ok(b) => Ok(b),
         Err(err) => {
-            // couldn't lift this out because of block_number
             warn!("{err:?}");
             log_unexpected_error_report(block_number, &err).await;
             Err(err)
         }
     }?;
-
-    info!("TRACING block {block_number} with Native. It has {tx_count} transactions");
 
     match native_trace_result.result {
         TraceResult::Success(native_trace) => {
@@ -152,65 +200,6 @@ async fn trace_native(
             Ok(None)
         }
     }
-}
-
-// TODO(xrvdg)
-// - rewrite the way it reads the base trace
-//   - using or not using cache is interesting for timing.
-//   - for cache invalidation (should be handled differently) -> check version number
-//   - rewrite in way that makes use of an option to continue or not
-// - move out error reporting
-// - rewriting the cache file (for speed performance or what?)
-// - remove panic
-async fn trace_base(
-    redo_traces: bool,
-    block_number: u64,
-    tx_count: u64,
-    base_juno: &mut JunoManager,
-) -> Result<Vec<TransactionTraceWithHash>, ManagerError> {
-    info!("TRACING block {block_number} with Base. It has {tx_count} transactions");
-    let using_cached_trace = !redo_traces && base_trace_path(block_number).exists();
-
-    // todo(xrvdg) possible to move out the awaits?
-    let base_trace_result = if redo_traces {
-        base_juno.trace_block(block_number).await
-    } else {
-        match read_base_trace(block_number).await {
-            Some(trace_block_report) => Ok(trace_block_report),
-            None => base_juno.trace_block(block_number).await,
-        }
-    };
-
-    let base_trace_result = match base_trace_result {
-        Ok(b) => Ok(b),
-        Err(err) => {
-            // couldn't lift this out because of block_number
-            warn!("{err:?}");
-            log_unexpected_error_report(block_number, &err).await;
-            Err(err)
-        }
-    }?;
-    let base_trace_result = match base_trace_result.result {
-        TraceResult::Success(trace) => {
-            if !using_cached_trace {
-                // todo(xrvdg)
-                // Have to clone because it wants to put it in a blocktracereport
-                log_base_trace(block_number, trace.clone()).await;
-            }
-            trace
-        }
-
-        base_report => {
-            // todo: prettier handling, but low prio.
-            let trace = serde_json::to_string_pretty(&base_report)
-                .unwrap_or(format!("Serialization failed!\n{base_report:?}"));
-
-            // todo(xrvdg) Early exit, but you can't use panic when doing multiple traces
-            // can now turn this into an error and exit early
-            panic!("Tracing with base juno is always expected to work. Check your base juno bin and config. Error:\n{}",trace);
-        }
-    };
-    Ok(base_trace_result)
 }
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,13 +139,13 @@ async fn execute_traces(
         // First branch is succesful block trace with Native
         // Second branch is an unhandled crash by the blockifier/native during tracing
         // Third branch is an unexpected crash by Juno Manager
-        match native_trace_result {
-            native_report if native_report.result.is_success() => {
+        match native_trace_result.result {
+            TraceResult::Success(native_report) => {
                 info!("SUCCESS tracing block with native");
                 if let Err(e) = graph::write_transaction_dependencies(
                     block_number,
                     "native",
-                    native_report.clone().result.as_success().unwrap().iter(),
+                    native_report.iter(),
                 ) {
                     warn!("Error writing transaction dependencies: {e:?}");
                 }

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -80,7 +80,7 @@ impl From<ComparisonResult> for Value {
 }
 
 fn trace_block_report_to_json(report: TraceBlockReport) -> Value {
-    let mut traces = report.post_response.unwrap_or_default();
+    let mut traces = report.result.as_success().unwrap_or_default();
 
     normalize_traces_state_diff(&mut traces);
 

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -119,14 +119,17 @@ fn normalize_traces_state_diff(traces: &mut Vec<TransactionTraceWithHash>) {
 pub fn generate_block_comparison(
     block_number: u64,
     base_report: Vec<TransactionTraceWithHash>,
-    native_report: TraceBlockReport,
+    native_report: Vec<TransactionTraceWithHash>,
 ) -> Value {
     compare_jsons(
         trace_block_report_to_json(TraceBlockReport {
             block_num: block_number,
             result: TraceResult::Success(base_report),
         }),
-        trace_block_report_to_json(native_report),
+        trace_block_report_to_json(TraceBlockReport {
+            block_num: block_number,
+            result: TraceResult::Success(native_report),
+        }),
     )
 }
 

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use starknet::core::types::{StateDiff, TransactionTrace, TransactionTraceWithHash};
 
-use crate::{block_tracer::TraceBlockReport, dependencies::block_report_with_dependencies};
+use crate::{
+    block_tracer::TraceBlockReport, dependencies::block_report_with_dependencies,
+    transaction_tracer::TraceResult,
+};
 
 const SAME: &str = "Same";
 const EMPTY: &str = "Empty";
@@ -112,12 +115,17 @@ fn normalize_traces_state_diff(traces: &mut Vec<TransactionTraceWithHash>) {
 // Take two JSONs and compare each (key, value) recursively.
 // It will consume the two JSON as well.
 // Store the resutls in an output JSON.
+// TODO(xrvdg) only use on successful blocks
 pub fn generate_block_comparison(
-    base_report: TraceBlockReport,
+    block_number: u64,
+    base_report: Vec<TransactionTraceWithHash>,
     native_report: TraceBlockReport,
 ) -> Value {
     compare_jsons(
-        trace_block_report_to_json(base_report),
+        trace_block_report_to_json(TraceBlockReport {
+            block_num: block_number,
+            result: TraceResult::Success(base_report),
+        }),
         trace_block_report_to_json(native_report),
     )
 }

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -45,7 +45,6 @@ impl From<&ProviderError> for TraceResult {
 impl Display for TraceResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            // todo(xrvdg) do we want to include the result here?
             TraceResult::Success(_) => write!(f, "TraceResult::Success"),
             TraceResult::OtherError(error) => write!(f, "TraceResult::OtherError: '{}'", error),
             TraceResult::NotFound => write!(f, "TraceResult::NotFound"),

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -9,10 +9,28 @@ use starknet::{
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TraceResult {
-    Success,
+    Success(Vec<TransactionTraceWithHash>),
     OtherError(String),
     NotFound,
     Crash { error: String },
+}
+
+// TODO(xrvdg) try to get rid of these again
+impl TraceResult {
+    pub fn is_success(&self) -> bool {
+        match self {
+            TraceResult::Success(_) => true,
+            _ => false,
+        }
+    }
+
+    // What were the naming convention rules about this again?
+    pub fn as_success(self) -> Option<Vec<TransactionTraceWithHash>> {
+        match self {
+            TraceResult::Success(vec) => Some(vec),
+            _ => None,
+        }
+    }
 }
 
 impl From<&ProviderError> for TraceResult {
@@ -45,7 +63,8 @@ impl From<&ProviderError> for TraceResult {
 impl Display for TraceResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            TraceResult::Success => write!(f, "TraceResult::Success"),
+            // todo(xrvdg) do we want to include the result here?
+            TraceResult::Success(_) => write!(f, "TraceResult::Success"),
             TraceResult::OtherError(error) => write!(f, "TraceResult::OtherError: '{}'", error),
             TraceResult::NotFound => write!(f, "TraceResult::NotFound"),
             TraceResult::Crash { error } => write!(f, "TraceResult::Crash: '{}'", error),

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -15,24 +15,6 @@ pub enum TraceResult {
     Crash { error: String },
 }
 
-// TODO(xrvdg) try to get rid of these again
-impl TraceResult {
-    pub fn is_success(&self) -> bool {
-        match self {
-            TraceResult::Success(_) => true,
-            _ => false,
-        }
-    }
-
-    // What were the naming convention rules about this again?
-    pub fn as_success(self) -> Option<Vec<TransactionTraceWithHash>> {
-        match self {
-            TraceResult::Success(vec) => Some(vec),
-            _ => None,
-        }
-    }
-}
-
 impl From<&ProviderError> for TraceResult {
     fn from(value: &ProviderError) -> Self {
         match value {

--- a/src/transaction_tracer.rs
+++ b/src/transaction_tracer.rs
@@ -1,14 +1,11 @@
 use std::fmt::Display;
 
-use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 use starknet::{
-    core::types::{FieldElement, StarknetError},
-    providers::{Provider, ProviderError},
+    core::types::{StarknetError, TransactionTraceWithHash},
+    providers::ProviderError,
 };
-
-use crate::juno_manager::{JunoBranch, JunoManager, ManagerError};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TraceResult {
@@ -54,67 +51,4 @@ impl Display for TraceResult {
             TraceResult::Crash { error } => write!(f, "TraceResult::Crash: '{}'", error),
         }
     }
-}
-
-pub struct TraceTransactionReport {
-    transaction: FieldElement, // Hash of transaction.
-    post_response: Result<starknet::core::types::TransactionTrace, ProviderError>,
-    result: TraceResult,
-}
-
-trait TransactionTracer {
-    async fn trace_transaction(
-        &mut self,
-        transaction_hash: &str,
-    ) -> Result<TraceTransactionReport, ManagerError>;
-}
-
-impl TransactionTracer for JunoManager {
-    async fn trace_transaction(
-        &mut self,
-        transaction_hash: &str,
-    ) -> Result<TraceTransactionReport, ManagerError> {
-        info!("Tracing transaction {transaction_hash}");
-        self.ensure_usable().await?;
-        let transaction = FieldElement::from_hex_be(transaction_hash)
-            .map_err(|e| ManagerError::Internal(format!("{}", e)))?;
-        let trace_result = self.rpc_client.trace_transaction(transaction).await;
-
-        let result_type = match &trace_result {
-            Ok(_) => TraceResult::Success,
-            Err(err) => {
-                warn!("err: '{:?}''", err);
-                TraceResult::from(err)
-            }
-        };
-        info!("{result_type}");
-
-        Ok(TraceTransactionReport {
-            transaction,
-            result: result_type,
-            post_response: trace_result,
-        })
-    }
-}
-
-#[allow(dead_code)]
-pub async fn transaction_hash_main() -> Result<(), ManagerError> {
-    // let hash = "0x6faeed8967da5d3c0853b8cf4b40b55661a0f949678d5509254b643d133b769"; // DNE
-    let hash = "0x07e3ace3b1c3f76b83b734b7a2ea990fb2823e931fb2ecef5d2677887aed9082"; // Crashes on native
-    let mut juno_manager = JunoManager::new(JunoBranch::Native).await?;
-    let trace_report = juno_manager.trace_transaction(hash).await?;
-    info!("transaction: {:?}", trace_report.transaction);
-    info!("result: {}", trace_report.result);
-    match trace_report.post_response {
-        Ok(item) => {
-            info!("item: {:?}", item);
-        }
-        Err(err) => {
-            warn!("error: {}", err);
-        }
-    };
-
-    info!("//Done {hash}");
-
-    Ok(())
 }


### PR DESCRIPTION
This PR refactors the blockifier-tester in preparation of parallelisation, it 
- creates space for join points for native and base. 
- simplifies to logic by 
    - reducing the illegal states `TraceBaseReport` can occupy
    - preventing that already known information gets erased by unnecessarily wrapping it in a `TraceBaseReport`.
- `read_base_trace` now invalidates caches if the cache format changed.





