### PR TITLE
fix: exclude duplicate calls for class hash and entry points

### DIFF
--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -434,6 +434,27 @@ mod tests {
     }
 
     #[test]
+    fn test_get_call_key() {
+        let call = json!({
+            "entry_point_selector": "Same(0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29)",
+            "class_hash": "Same(0x3e8d67c8817de7a2185d418e88d321c89772a9722b752c6fe097192114621be)"
+        });
+
+        let call_key = get_call_key(&call).unwrap();
+        let expected_key = (
+            FieldElement::from_hex_be(
+                "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29",
+            )
+            .unwrap(),
+            FieldElement::from_hex_be(
+                "0x3e8d67c8817de7a2185d418e88d321c89772a9722b752c6fe097192114621be",
+            )
+            .unwrap(),
+        );
+        assert_eq!(call_key, expected_key);
+    }
+
+    #[test]
     fn test_get_calls() {
         let obj = json!({
             "calls": [

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -315,10 +315,10 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
                 if let Some(Value::Object(diff_map)) = obj_map.get(DIFFERENT) {
                     let base_list = diff_map
                         .get("base")
-                        .ok_or(anyhow!("difference should have base"))?;
+                        .ok_or(anyhow!("Different should have base"))?;
                     let native_list = diff_map
                         .get("native")
-                        .ok_or(anyhow!("difference should have native"))?;
+                        .ok_or(anyhow!("Different should have native"))?;
 
                     let mut base_calls = HashMap::new();
                     get_calls_inner(base_list, &mut base_calls)?;

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -300,7 +300,7 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
                 if string_is_same(string) || string_is_empty(string) {
                     Ok(())
                 } else {
-                    Err(anyhow!("unexpected string: {}", string))
+                    Err(anyhow!("String is not SAME or EMPTY: {}", string))
                 }
             }
             Value::Array(call_list) => {

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -394,21 +394,6 @@ mod tests {
     }
 
     #[test]
-    fn test_class_hashes_report_add_fields() {
-        let mut report = ClassHashesReport::new();
-        let class_hash = FieldElement::from_hex_be("0x789").unwrap();
-        let entry_point = FieldElement::from_hex_be("0xabc").unwrap();
-
-        report.add_fields(class_hash, entry_point);
-        assert_eq!(report.report[&class_hash][&entry_point], 1);
-        assert_eq!(report.totals[&class_hash], 1);
-
-        report.add_fields(class_hash, entry_point);
-        assert_eq!(report.report[&class_hash][&entry_point], 2);
-        assert_eq!(report.totals[&class_hash], 2);
-    }
-
-    #[test]
     fn test_get_tuple_from_call() {
         let call = json!({
             "entry_point_selector": "0x123",

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -301,13 +301,11 @@ fn get_calls_with_count(obj: &Value) -> Result<Vec<CallWithCount>, anyhow::Error
                 Err(anyhow!("unexpected string: {}", string))
             }
         }
-        Value::Array(call_list) => {
-            let mut result = Vec::new();
-            for call in call_list {
-                result.extend(get_calls_with_count(call)?);
-            }
-            Ok(result)
-        }
+        Value::Array(call_list) => Ok(call_list
+            .iter()
+            .filter_map(|call| get_calls_with_count(call).ok())
+            .flatten()
+            .collect_vec()),
         Value::Object(obj_map) => {
             let mut result = Vec::new();
             // If call is different, then base and native will have their own list of calls

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -269,7 +269,7 @@ fn update_report(
 /// Merges two lists of calls into a single list of calls. We only consider a [CallWithCount] if
 /// it exists in both lists.
 ///
-/// This means that if native is empty, then no calls will be added to the merged list.
+/// For example if either base or native is empty, then no calls from the other will be added to the merged list
 fn merge_calls_with_count(
     base_calls: Vec<CallWithCount>,
     native_calls: Vec<CallWithCount>,
@@ -358,7 +358,7 @@ fn get_calls_with_count(obj: &Value) -> Result<Vec<CallWithCount>, anyhow::Error
 
 /// Retrieves a [CallWithCount] from a call object.
 ///
-/// If any of the keys are Different, then the call is considered invalid.
+/// If any of the keys are Different, then the call is considered invalid and this function will return an Error.
 fn get_call_with_count(call: &Value) -> Result<CallWithCount, anyhow::Error> {
     let keys = ["entry_point_selector", "class_hash"];
     let mut values = Vec::with_capacity(keys.len());

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -357,12 +357,10 @@ fn get_call_key(call: &Value) -> Result<CallKey, anyhow::Error> {
         call.get(key)
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow!("Failed to parse call {call} for key: {key}"))
-            .and_then(|s| {
-                if string_is_same(s) {
-                    parse_same_string(s).context(anyhow!("Failed to parse SAME value"))
-                } else {
-                    Ok(s)
-                }
+            .and_then(|s| match parse_same_string(s) {
+                Ok(value) => Ok(value),
+                // If the string is not a Same comparison result, then it must be the actual value
+                Err(_) => Ok(s),
             })
             .and_then(|v| {
                 FieldElement::from_hex_be(v).context(format!("Failed to convert value to felt"))

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -293,8 +293,8 @@ fn get_calls<'a>(
 
     match obj {
         Value::String(string) => {
-            if string_is_same(string) {
-                Ok(Box::new(::std::iter::empty()))
+            if string_is_same(string) || string_is_empty(string) {
+                Ok(Vec::new())
             } else {
                 Err(anyhow!("unexpected string: {}", string))
             }

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -299,7 +299,6 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
             Value::String(string) if string_is_same(string) || string_is_empty(string) => {
                 Ok(result)
             }
-            Value::String(string) => Err(anyhow!("String is not SAME or EMPTY: {}", string)),
             Value::Array(call_list) => {
                 for call in call_list {
                     result = get_calls_inner(call, result)?;
@@ -708,7 +707,7 @@ mod tests {
         assert_eq!(calls.get(&expected_key), Some(&8));
     }
 
-    // TODO: uncomment this test once get_calls_with_count handles different depths of CallKeys
+    // TODO(#91): uncomment this test once get_calls_with_count handles different depths of CallKeys
     // #[test]
     // fn test_get_calls_with_count_different_layers() {
     //     let obj = json!({

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -305,7 +305,9 @@ fn get_calls_with_count(obj: &Value) -> Result<Vec<CallWithCount>, anyhow::Error
         }
         Value::Array(call_list) => Ok(call_list
             .iter()
-            .filter_map(|call| get_calls_with_count(call).ok())
+            .map(|call| get_calls_with_count(call))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
             .flatten()
             .collect_vec()),
         Value::Object(obj_map) => {

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -388,7 +388,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_merge_calls_with_count() {
+    fn test_get_call_with_count() {
         let ep1 = FieldElement::from_hex_be("0x111").unwrap();
         let ep2 = FieldElement::from_hex_be("0x222").unwrap();
         let ch1 = FieldElement::from_hex_be("0xaaa").unwrap();
@@ -406,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_calls_with_count_empty_native() {
+    fn test_get_call_with_count_empty_native() {
         let ep1 = FieldElement::from_hex_be("0x111").unwrap();
         let ch1 = FieldElement::from_hex_be("0xaaa").unwrap();
 
@@ -420,7 +420,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_calls_with_count_empty_base() {
+    fn test_get_call_with_count_empty_base() {
         let ep1 = FieldElement::from_hex_be("0x111").unwrap();
         let ch1 = FieldElement::from_hex_be("0xaaa").unwrap();
 
@@ -434,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_calls_with_count_multiple_occurrences() {
+    fn test_get_call_with_count_multiple_occurrences() {
         let ep1 = FieldElement::from_hex_be("0x111").unwrap();
         let ch1 = FieldElement::from_hex_be("0xaaa").unwrap();
 

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -346,6 +346,7 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
 /// Retrieves a [CallKey] from a call object.
 ///
 /// If any of the keys are Different, then the call is considered invalid and this function will return an Error.
+// TODO: can take ownership of call here, same with the other get call functions
 fn get_call_key(call: &Map<String, Value>) -> Result<CallKey, anyhow::Error> {
     let parse_field = |key: &str| -> Result<FieldElement, anyhow::Error> {
         call.get(key)

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -346,7 +346,6 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
 /// Retrieves a [CallKey] from a call object.
 ///
 /// If any of the keys are Different, then the call is considered invalid and this function will return an Error.
-// TODO: can take ownership of call here, same with the other get call functions
 fn get_call_key(call: &Map<String, Value>) -> Result<CallKey, anyhow::Error> {
     let parse_field = |key: &str| -> Result<FieldElement, anyhow::Error> {
         call.get(key)

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -296,14 +296,10 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
         mut result: HashMap<CallKey, usize>,
     ) -> Result<HashMap<CallKey, usize>, anyhow::Error> {
         match obj {
-            Value::String(string) => {
-                // If the string is SAME or EMPTY, then there are no calls to extract and continue processing
-                if string_is_same(string) || string_is_empty(string) {
-                    Ok(result)
-                } else {
-                    Err(anyhow!("String is not SAME or EMPTY: {}", string))
-                }
+            Value::String(string) if string_is_same(string) || string_is_empty(string) => {
+                Ok(result)
             }
+            Value::String(string) => Err(anyhow!("String is not SAME or EMPTY: {}", string)),
             Value::Array(call_list) => {
                 for call in call_list {
                     result = get_calls_inner(call, result)?;
@@ -345,8 +341,7 @@ fn get_calls_with_count(obj: &Value) -> Result<HashMap<CallKey, usize>, anyhow::
         }
     }
 
-    let result = get_calls_inner(obj, HashMap::new())?;
-    Ok(result)
+    get_calls_inner(obj, HashMap::new())
 }
 
 /// Retrieves a [CallKey] from a call object.

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -722,4 +722,70 @@ mod tests {
         );
         assert_eq!(calls.get(&expected_key), Some(&8));
     }
+
+    // TODO: uncomment this test once get_calls_with_count handles different depths of CallKeys
+    // #[test]
+    // fn test_get_calls_with_count_different_layers() {
+    //     let obj = json!({
+    //         "calls": {
+    //             "Different": {
+    //                 "base": [
+    //                     {
+    //                         "entry_point_selector": "Same(0x111)",
+    //                         "class_hash": "Same(0xaaa)",
+    //                         "calls": [
+    //                             {
+    //                                 "entry_point_selector": "Same(0x222)",
+    //                                 "class_hash": "Same(0xaaa)",
+    //                                 "calls": [
+    //                                     {
+    //                                         "entry_point_selector": "Same(0x333)",
+    //                                         "class_hash": "Same(0xaaa)",
+    //                                         "calls": []
+    //                                     }
+    //                                 ]
+    //                             }
+    //                         ]
+    //                     }
+    //                 ],
+    //                 "native": [
+    //                     {
+    //                         "entry_point_selector": "Same(0x111)",
+    //                         "class_hash": "Same(0xaaa)",
+    //                         "calls": [
+    //                             {
+    //                                 "entry_point_selector": "Same(0x333)",
+    //                                 "class_hash": "Same(0xaaa)",
+    //                                 "calls": []
+    //                             }
+    //                         ]
+    //                     }
+    //                 ]
+    //             }
+    //         }
+    //     });
+
+    //     let calls = get_calls_with_count(&obj).unwrap();
+    //     println!("Calls {:?}", calls);
+    //     assert_eq!(calls.len(), 1);
+
+    //     let expected_key = (
+    //         FieldElement::from_hex_be("0x111").unwrap(),
+    //         FieldElement::from_hex_be("0xaaa").unwrap(),
+    //     );
+    //     assert_eq!(calls.get(&expected_key), Some(&1));
+
+    //     // Ensure that call_2 and call_3 are not in the result
+    //     let call_2_key = (
+    //         FieldElement::from_hex_be("0x222").unwrap(),
+    //         FieldElement::from_hex_be("0xaaa").unwrap(),
+    //     );
+    //     assert_eq!(calls.get(&call_2_key), None);
+
+    //     let call_3_key = (
+    //         FieldElement::from_hex_be("0x333").unwrap(),
+    //         FieldElement::from_hex_be("0xaaa").unwrap(),
+    //     );
+    //     assert_eq!(calls.get(&call_3_key), None);
+    // }
 }

--- a/src/gather_classes.rs
+++ b/src/gather_classes.rs
@@ -86,10 +86,6 @@ impl ClassHashesReport {
         let totals_entry = self.totals.entry(class_hash).or_insert(0);
         *totals_entry += count;
     }
-
-    fn add_fields(&mut self, class_hash: ClassHash, entry_point: EntryPoint) {
-        self.update_count(class_hash, entry_point, 1)
-    }
 }
 
 impl core::fmt::Display for ClassHashesReport {

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -445,11 +445,25 @@ fn clean_json_array(arr: Vec<Value>) -> Value {
     }
 }
 
+pub(crate) fn parse_same_value(val: Value) -> Result<Value, anyhow::Error> {
+    if let Value::String(string) = val {
+        if string.starts_with(SAME) {
+            return Ok(Value::String(
+                string
+                    .trim_start_matches(format!("{SAME}(").as_str())
+                    .trim_end_matches(")")
+                    .to_string(),
+            ));
+        }
+    }
+    return Err(anyhow::anyhow!("Value is not a SAME value"));
+}
+
 pub(crate) fn string_is_same(string: &str) -> bool {
     string.starts_with(SAME)
 }
 
-fn value_is_same(val: &Value) -> bool {
+pub(crate) fn value_is_same(val: &Value) -> bool {
     matches!(val, Value::String(str) if string_is_same(str))
 }
 

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -463,6 +463,10 @@ pub(crate) fn string_is_same(string: &str) -> bool {
     string.starts_with(SAME)
 }
 
+pub(crate) fn string_is_empty(string: &str) -> bool {
+    string == EMPTY
+}
+
 pub(crate) fn value_is_same(val: &Value) -> bool {
     matches!(val, Value::String(str) if string_is_same(str))
 }

--- a/src/trace_comparison.rs
+++ b/src/trace_comparison.rs
@@ -445,16 +445,11 @@ fn clean_json_array(arr: Vec<Value>) -> Value {
     }
 }
 
-pub(crate) fn parse_same_value(val: Value) -> Result<Value, anyhow::Error> {
-    if let Value::String(string) = val {
-        if string.starts_with(SAME) {
-            return Ok(Value::String(
-                string
-                    .trim_start_matches(format!("{SAME}(").as_str())
-                    .trim_end_matches(")")
-                    .to_string(),
-            ));
-        }
+pub(crate) fn parse_same_string(string: &str) -> Result<&str, anyhow::Error> {
+    if string.starts_with(SAME) {
+        return Ok(string
+            .trim_start_matches(format!("{SAME}(").as_str())
+            .trim_end_matches(")"));
     }
     return Err(anyhow::anyhow!("Value is not a SAME value"));
 }


### PR DESCRIPTION
Fixes #85

## Changes

1. `get_calls_with_count` now returns a `HashMap<(EntryPoint, ClassHash), usize>`
    - this was previously called `get_calls`, which returned a list of possible tuple values, but I chose to return the concrete `(EntryPoint, ClassHash)` pairs instead for clarity
2. updated call `Value` parsing, which can now parse keys that have `"Same(0x123)"` values
    - previously, the function could only parse from `"0x123"` values, which meant that the parsing of some calls terminated early because of the `"Same"` prefix 
3. update unit tests for `get_calls_with_count` and added some for helper functions

## Notes

- Currently, there is an edge case when there are nested calls in different depths with the same entry point and class hash tuple, which will be resolved in #91
- If base has `[(ch1, ep1), (ch2, ep2)]` and native has `[(ch1, ep1)]`, we only count `(ch1, ep1)` pair once
- When native has no calls, i.e.  `"Empty"` or `[]`, then `get_calls_with_count` will return `[]`
