### PR TITLE
feat: spawn threads to process each path

### DIFF
--- a/results-mainnet/comparison-633333.json
+++ b/results-mainnet/comparison-633333.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:664fe74917d54acaa2b15d0bda45e202857f53fad3c331fbe67859b2213a1ec1
-size 22340311


### PR DESCRIPTION
Fixes #90 

## Changes

1. made the individual file processing function async with tokio
2. add a maximum number of concurrent block processes to avoid spawning too many threads

